### PR TITLE
Fix issue with file extension parsing and yaml file rendering.

### DIFF
--- a/levant/templater.go
+++ b/levant/templater.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	terraformVarExtention = "tf"
-	yamlVarExtension      = "yaml"
-	ymlVarExtension       = "yml"
+	terraformVarExtention = ".tf"
+	yamlVarExtension      = ".yaml"
+	ymlVarExtension       = ".yml"
 )
 
 // RenderTemplate is the main entry point to render the template based on the
@@ -118,8 +118,7 @@ func renderYAMLVarsTemplate(src, variableFile string, flagVars *map[string]strin
 
 	// Setup the template file for rendering
 	t := template.New("jobTemplate")
-	tempF, _ := ioutil.ReadFile(src)
-	if t, err = t.Parse(string(tempF)); err != nil {
+	if t, err = t.Parse(string(src)); err != nil {
 		return
 	}
 


### PR DESCRIPTION
This changes fixes two bugs introduced in 1ca427e33. The first is
that variable files extensions are not being matched due to a
change in the extension discovery which now means the `.` is
included whereas previously it was not.

The second fixes an issue where templates using a yaml/yml file
extension were not being rendered.

Closes #4
Closes #5