### PR TITLE
Levant now uses `[[ ]]` for variable interpolation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Levant is an open source templating and deployment tool for [HashiCorp Nomad](ht
 
 ## Variable File Examples
 
-Levant currently supports `.tf`, `.yaml` and `.yml` file extensions for the declaration of template variables which look like:
+Levant currently supports `.tf`, `.yaml` and `.yml` file extensions for the declaration of template variables and uses opening and closing double squared brackets `[[ ]]` within the templated job file. This is to ensure there is no clash with existing Nomad interpolation which uses the standard `{{ }}` notation.
 
 Job Template:
 ```hcl
-job "{{.job_name}}" {
+job "[[.job_name]]" {
   datacenters = ["dc1"]
   ...
 ```

--- a/levant/templater.go
+++ b/levant/templater.go
@@ -85,7 +85,7 @@ func renderTFTemplte(src, variableFile string, flagVars *map[string]string) (tpl
 	mergedVars := helper.VariableMerge(&variables, flagVars)
 
 	// Setup the template file for rendering
-	t := template.New("jobTemplate")
+	t := template.New("jobTemplate").Delims("[[", "]]")
 
 	if t, err = t.Parse(src); err != nil {
 		return
@@ -117,7 +117,7 @@ func renderYAMLVarsTemplate(src, variableFile string, flagVars *map[string]strin
 	mergedVars := helper.VariableMerge(&variables, flagVars)
 
 	// Setup the template file for rendering
-	t := template.New("jobTemplate")
+	t := template.New("jobTemplate").Delims("[[", "]]")
 	if t, err = t.Parse(string(src)); err != nil {
 		return
 	}
@@ -134,7 +134,7 @@ func readJobFile(src string, flagVars *map[string]string) (tpl *bytes.Buffer, er
 	tpl = &bytes.Buffer{}
 
 	// Setup the template file for rendering
-	t := template.New("jobTemplate")
+	t := template.New("jobTemplate").Delims("[[", "]]")
 	if t, err = t.Parse(src); err != nil {
 		return
 	}

--- a/levant/test-fixtures/multi_templated.nomad
+++ b/levant/test-fixtures/multi_templated.nomad
@@ -1,5 +1,5 @@
-job "{{.job_name}}" {
-  datacenters = ["{{.datacentre}}"]
+job "[[.job_name]]" {
+  datacenters = ["[[.datacentre]]"]
   type = "service"
   update {
     max_parallel     = 1
@@ -22,7 +22,7 @@ job "{{.job_name}}" {
     task "redis" {
       driver = "docker"
       config {
-        image = "redis:13.2"
+        image = "redis:3.2"
         port_map {
           db = 6379
         }

--- a/levant/test-fixtures/none_templated.nomad
+++ b/levant/test-fixtures/none_templated.nomad
@@ -22,7 +22,7 @@ job "levantExample" {
     task "redis" {
       driver = "docker"
       config {
-        image = "redis:13.2"
+        image = "redis:3.2"
         port_map {
           db = 6379
         }

--- a/levant/test-fixtures/single_templated.nomad
+++ b/levant/test-fixtures/single_templated.nomad
@@ -1,4 +1,4 @@
-job "{{.job_name}}" {
+job "[[.job_name]]" {
   datacenters = ["dc1"]
   type = "service"
   update {
@@ -20,9 +20,20 @@ job "{{.job_name}}" {
       size = 300
     }
     task "redis" {
+      template {
+        data = <<EOH
+        APP_ENV={{ key "config/app/env" }}
+        APP_DEBUG={{ key "config/app/debug" }}
+        APP_KEY={{ secret "secret/key" }}
+        APP_URL={{ key "config/app/url" }}
+        EOH
+        destination = "core/.env"
+        change_mode = "noop"
+      }
+
       driver = "docker"
       config {
-        image = "redis:13.2"
+        image = "redis:3.2"
         port_map {
           db = 6379
         }


### PR DESCRIPTION
Nomad uses the standard `{{ }}` for variable interpolation which
causes conflicts if used in conjunction with Levant. This change
moves Levant to use `[[ variable]]` which removes conflicts with
standard Nomad interpolation and allows both to be used together.

Tests have been updated to check for this also.

Closes #3