### PR TITLE
 Introduce canary-auto-promote which allows for canary promotion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Levant is an open source templating and deployment tool for [HashiCorp Nomad](ht
 
 * **Failure Inspection**: Upon a deployment failure, Levant will inspect each allocation and log information about each event, providing useful information for debugging without the need for querying the cluster retrospectively.
 
+* **Canary Auto Promotion**: In environments with advanced automation and alerting, automatic promotion of canary deployments may be desirable after a certain time threshold. Levant allows the user to specify a `canary-auto-promote` time period, which if reached with a healthy set of canaries, will automatically promote the deployment.
+
 * **Multiple Variable File Formats**: Currently Levant supports `.tf`, `.yaml` and `.yml` file extensions for the declaration of template variables. *This is planned to increase in the near future.*
 
 ## Download
@@ -53,9 +55,11 @@ Levant supports a number of command line arguments which provide control over th
 
 ### Command: `deploy`
 
-`Deploy` is the main entry point into Levant for deploying a Nomad job and supports the following flags which should then be proceded by the Nomad job template you which to deploy. An example deployment command would look like `levant -log-level=debug example.nomad`.
+`Deploy` is the main entry point into Levant for deploying a Nomad job and supports the following flags which should then be proceeded by the Nomad job template you which to deploy. An example deployment command would look like `levant -log-level=debug example.nomad`.
 
 * **-address** (string: "http://localhost:4646") The HTTP API endpoint for Nomad where all calls will be made.
+
+* **-canary-auto-promote** (int: 0)
 
 * **-log-level** (string: "INFO") The level at which Levant will log to. Valid values are DEBUG, INFO, WARNING, ERROR and FATAL.
 
@@ -82,7 +86,7 @@ Like `deploy`, the `render` command also supports passing variables individually
 Full example:
 
 ```
-levant render -var-file=var.yaml -var 'var=test' render example.nomad
+levant render -var-file=var.yaml -var 'var=test' example.nomad
 ```
 
 ### Command: `version`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Levant supports a number of command line arguments which provide control over th
 
 * **-address** (string: "http://localhost:4646") The HTTP API endpoint for Nomad where all calls will be made.
 
-* **-canary-auto-promote** (int: 0)
+* **-canary-auto-promote** (int: 0) The time period in seconds that Levant should wait for before attempting to promote a canary deployment.
 
 * **-log-level** (string: "INFO") The level at which Levant will log to. Valid values are DEBUG, INFO, WARNING, ERROR and FATAL.
 

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -85,9 +85,11 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err = c.checkCanaryAutoPromote(job, canary); err != nil {
-		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
-		return 1
+	if canary > 0 {
+		if err = c.checkCanaryAutoPromote(job, canary); err != nil {
+			c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
+			return 1
+		}
 	}
 
 	client, err := levant.NewNomadClient(addr)
@@ -113,7 +115,7 @@ func (c *DeployCommand) checkCanaryAutoPromote(job *nomad.Job, canaryAutoPromote
 		return fmt.Errorf("canary-auto-update of %v passed but job is not canary enabled", canaryAutoPromote)
 	}
 
-	c.UI.Info(fmt.Sprintf("[INFO] levant/command: running canary-auto-update of %v", canaryAutoPromote))
+	c.UI.Info(fmt.Sprintf("[INFO] levant/command: running canary-auto-update of %vs", canaryAutoPromote))
 
 	return nil
 }

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -167,7 +167,7 @@ func (c *nomadClient) canaryAutoPromote(depID string, waitTime int, shutdownChan
 				waitTime, depID)
 
 			// Check the deployment is healthy before promoting.
-			if healthly := c.checkCanaryDeploymentHealth(depID); !healthly {
+			if healthy := c.checkCanaryDeploymentHealth(depID); !healthy {
 				logging.Error("levant/deploy: the canary deployment %s has unhealthy allocations, unable to promote", depID)
 				close(deploymentChan)
 				return
@@ -213,7 +213,7 @@ func (c *nomadClient) checkCanaryDeploymentHealth(depID string) (healthy bool) {
 
 	// If zero unhealthy tasks were found, continue with the auto promotion.
 	if unhealthy == 0 {
-		logging.Info("levant/deploy: deployment %s has 0 unhealthy allocations", depID)
+		logging.Debug("levant/deploy: deployment %s has 0 unhealthy allocations", depID)
 		healthy = true
 	}
 

--- a/levant/failure_inspector.go
+++ b/levant/failure_inspector.go
@@ -57,13 +57,13 @@ func (c *nomadClient) allocInspector(allocID *string, wg *sync.WaitGroup) {
 		for _, event := range task.Events {
 			switch event.Type {
 			case nomad.TaskDriverFailure:
-				logging.Info("levant/failure_inspector: allocation %v incurred %v due to %s",
+				logging.Error("levant/failure_inspector: allocation %v incurred %v due to %s",
 					*allocID, nomad.TaskDriverFailure, strings.TrimSpace(event.DriverError))
 			case nomad.TaskGenericMessage:
-				logging.Info("levant/failure_inspector: allocation %v incurred %v due to %s",
+				logging.Error("levant/failure_inspector: allocation %v incurred %v due to %s",
 					*allocID, nomad.TaskGenericMessage, strings.TrimSpace(event.Message))
 			case nomad.TaskArtifactDownloadFailed:
-				logging.Info("levant/failure_inspector: allocation %v incurred %v due to %s",
+				logging.Error("levant/failure_inspector: allocation %v incurred %v due to %s",
 					*allocID, nomad.TaskArtifactDownloadFailed, strings.TrimSpace(event.DownloadError))
 			}
 		}


### PR DESCRIPTION
Levant now supports auto promoting a canary deployment using the
-canary-auto-promote flag which accepts a value in seconds. If
after this time, Levant will check the canary alloc health, and if
healthy will promote the deployment.

Any feedback from @ericwestfall or @mimato would be appreciated.

Closes #15 