### PR TITLE
Update failure_inspector to cover more cases.

### DIFF
--- a/levant/failure_inspector.go
+++ b/levant/failure_inspector.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	nomad "github.com/hashicorp/nomad/api"
 	"github.com/jrasell/levant/logging"
-	nomad "github.com/jrasell/nomad/api"
 )
 
 // checkFailedDeployment helps log information about deployment failures.


### PR DESCRIPTION
Previously, Levant was only able to catch a small number of alloc
failure cases. This changes expands the case statement with the
ability to catch many more.

Closes #26