### PR TITLE
Fix a bug in handling Nomad job types incorrectly.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -64,7 +64,7 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int) (success bool) {
 	case nomadStructs.JobTypeService:
 		logging.Debug("levant/deploy: beginning deployment watcher for job %s", *job.Name)
 		success = c.deploymentWatcher(eval.EvalID, autoPromote)
-	case nomadStructs.JobTypeBatch, nomadStructs.JobTypeSystem:
+	default:
 		logging.Debug("levant/deploy: job type %s does not support Nomad deployment model", *job.Type)
 		success = true
 	}


### PR DESCRIPTION
The case statement did not have a default clause when assesssing
the Nomad job type. This caused Levant to panic on some runs as
type is not an explicit type.

The change adds a default case to catch all job types which do not
support deployments.

Closes #31