### PR TITLE
introduce -force-count into Deploy

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -41,6 +41,10 @@ General Options:
   -var-file=<file>
     Used in conjunction with the -job-file will deploy a templated job to your
     Nomad cluster.
+
+  -force-count
+    Use the taskgroup count from the Nomad jobfile instead of the count that
+    is currently set in a running job.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -57,6 +61,7 @@ func (c *DeployCommand) Run(args []string) int {
 	var err error
 	var job *nomad.Job
 	var canary int
+	var forceCount bool
 
 	flags := c.Meta.FlagSet("deploy", FlagSetVars)
 	flags.Usage = func() { c.UI.Output(c.Help()) }
@@ -65,6 +70,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.IntVar(&canary, "canary-auto-promote", 0, "")
 	flags.StringVar(&log, "log-level", "INFO", "")
 	flags.StringVar(&variables, "var-file", "", "")
+	flags.BoolVar(&forceCount, "force-count", false, "")
 
 	if err = flags.Parse(args); err != nil {
 		return 1
@@ -98,7 +104,7 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	success := client.Deploy(job, canary)
+	success := client.Deploy(job, canary, forceCount)
 	if !success {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: deployment of job %s failed", *job.Name))
 		return 1

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -18,7 +18,7 @@ type nomadClient struct {
 type NomadClient interface {
 	// Deploy triggers a register of the job resulting in a Nomad deployment which
 	// is monitored to determine the eventual state.
-	Deploy(*nomad.Job, int) bool
+	Deploy(*nomad.Job, int, bool) bool
 }
 
 // NewNomadClient is used to create a new client to interact with Nomad.
@@ -39,7 +39,7 @@ func NewNomadClient(addr string) (NomadClient, error) {
 
 // Deploy triggers a register of the job resulting in a Nomad deployment which
 // is monitored to determine the eventual state.
-func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int) (success bool) {
+func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (success bool) {
 
 	// Validate the job to check it is syntactically correct.
 	if _, _, err := c.nomad.Jobs().Validate(job, nil); err != nil {
@@ -47,9 +47,11 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int) (success bool) {
 		return
 	}
 
-	logging.Debug("levant/deploy: running dynamic job count updater for job %s", *job.Name)
-	if err := c.dynamicGroupCountUpdater(job); err != nil {
-		return
+	if !forceCount {
+		logging.Debug("levant/deploy: running dynamic job count updater for job %s", *job.Name)
+		if err := c.dynamicGroupCountUpdater(job); err != nil {
+			return
+		}
 	}
 
 	logging.Info("levant/deploy: triggering a deployment of job %s", *job.Name)


### PR DESCRIPTION
  When deploying it would be nice to have a way to force the taskgroup
  count which is set in the Nomad jobfile. Currently the count is
  determined based on the actively running count which is understandable
  but doesn't apply for all use cases.