### PR TITLE
verify job.Type isn't nil before continuing

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -47,6 +47,12 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int) (success bool) {
 		return
 	}
 
+	// If job.Type isn't set we can't continue
+	if job.Type == nil {
+		logging.Error("levant/deploy: Nomad job `type` is not set. Should be set to `service`")
+		return
+	}
+
 	logging.Debug("levant/deploy: running dynamic job count updater for job %s", *job.Name)
 	if err := c.dynamicGroupCountUpdater(job); err != nil {
 		return

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -49,7 +49,7 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int) (success bool) {
 
 	// If job.Type isn't set we can't continue
 	if job.Type == nil {
-		logging.Error("levant/deploy: Nomad job `type` is not set. Should be set to `service`")
+		logging.Error("levant/deploy: Nomad job `type` is not set, should be set to `service`")
 		return
 	}
 


### PR DESCRIPTION
  The switch will still lead to a SEGV as the dereference is to a nil
  pointer. First verify that job.Type isn't nil.

  Still the same issue as here: https://github.com/jrasell/levant/issues/31