### PR TITLE
autoloading of files

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -46,7 +46,7 @@ General Options:
 
   -var-file=<file>
     Used in conjunction with the -job-file will deploy a templated job to your
-    Nomad cluster. [default: levant.tf]
+    Nomad cluster. [default: levant.(yaml|yml|tf)]
 
   -force-count
     Use the taskgroup count from the Nomad jobfile instead of the count that

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -2,11 +2,11 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	nomad "github.com/hashicorp/nomad/api"
 
+	"github.com/jrasell/levant/helper"
 	"github.com/jrasell/levant/levant"
 	"github.com/jrasell/levant/logging"
 )
@@ -27,7 +27,8 @@ Usage: levant deploy [options] [TEMPLATE]
 
 Arguments:
 
-  TEMPLATE  nomad job template [default: levant.nomad]
+  TEMPLATE  nomad job template
+    If no argument is given we look for a single *.nomad file
 
 General Options:
 
@@ -83,11 +84,12 @@ func (c *DeployCommand) Run(args []string) int {
 
 	args = flags.Args()
 
+	logging.SetLevel(log)
+
 	if len(args) == 1 {
 		templateFile = args[0]
 	} else if len(args) == 0 {
-		templateFile = "levant.nomad"
-		if _, err := os.Stat(templateFile); os.IsNotExist(err) {
+		if templateFile = helper.GetDefaultTmplFile(); templateFile == "" {
 			c.UI.Error(c.Help())
 			return 1
 		}
@@ -95,8 +97,6 @@ func (c *DeployCommand) Run(args []string) int {
 		c.UI.Error(c.Help())
 		return 1
 	}
-
-	logging.SetLevel(log)
 
 	job, err = levant.RenderJob(templateFile, variables, &c.Meta.flagVars)
 	if err != nil {

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -83,14 +83,17 @@ func (c *DeployCommand) Run(args []string) int {
 
 	args = flags.Args()
 
-	if len(args) != 1 {
+	if len(args) == 1 {
+		templateFile = args[0]
+	} else if len(args) == 0 {
 		templateFile = "levant.nomad"
 		if _, err := os.Stat(templateFile); os.IsNotExist(err) {
 			c.UI.Error(c.Help())
 			return 1
 		}
 	} else {
-		templateFile = args[0]
+		c.UI.Error(c.Help())
+		return 1
 	}
 
 	logging.SetLevel(log)

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -91,6 +91,7 @@ func (c *DeployCommand) Run(args []string) int {
 	} else if len(args) == 0 {
 		if templateFile = helper.GetDefaultTmplFile(); templateFile == "" {
 			c.UI.Error(c.Help())
+			c.UI.Error("\nERROR: Template arg missing and no default template found")
 			return 1
 		}
 	} else {

--- a/command/render.go
+++ b/command/render.go
@@ -37,7 +37,7 @@ General Options:
     rendered to stdout if this is not set.
 
   -var-file=<file>
-    The variables file to render the template with. [default: levant.tf]
+    The variables file to render the template with. [default: levant.(yaml|yml|tf)]
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/render.go
+++ b/command/render.go
@@ -64,14 +64,17 @@ func (c *RenderCommand) Run(args []string) int {
 
 	args = flags.Args()
 
-	if len(args) != 1 {
+	if len(args) == 1 {
+		templateFile = args[0]
+	} else if len(args) == 0 {
 		templateFile = "levant.nomad"
 		if _, err := os.Stat(templateFile); os.IsNotExist(err) {
 			c.UI.Error(c.Help())
 			return 1
 		}
 	} else {
-		templateFile = args[0]
+		c.UI.Error(c.Help())
+		return 1
 	}
 
 	tpl, err = levant.RenderTemplate(templateFile, variables, &c.Meta.flagVars)

--- a/command/render.go
+++ b/command/render.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jrasell/levant/helper"
 	"github.com/jrasell/levant/levant"
 )
 
@@ -25,7 +26,8 @@ Usage: levant render [options] [TEMPLATE]
 
 Arguments:
 
-  TEMPLATE  nomad job template [default: levant.nomad]
+  TEMPLATE  nomad job template
+    If no argument is given we look for a single *.nomad file
 
 General Options:
 	
@@ -67,8 +69,7 @@ func (c *RenderCommand) Run(args []string) int {
 	if len(args) == 1 {
 		templateFile = args[0]
 	} else if len(args) == 0 {
-		templateFile = "levant.nomad"
-		if _, err := os.Stat(templateFile); os.IsNotExist(err) {
+		if templateFile = helper.GetDefaultTmplFile(); templateFile == "" {
 			c.UI.Error(c.Help())
 			return 1
 		}

--- a/command/render.go
+++ b/command/render.go
@@ -71,6 +71,7 @@ func (c *RenderCommand) Run(args []string) int {
 	} else if len(args) == 0 {
 		if templateFile = helper.GetDefaultTmplFile(); templateFile == "" {
 			c.UI.Error(c.Help())
+			c.UI.Error("\nERROR: Template arg missing and no default template found")
 			return 1
 		}
 	} else {

--- a/helper/files.go
+++ b/helper/files.go
@@ -1,0 +1,40 @@
+package helper
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/jrasell/levant/logging"
+)
+
+// GetDefaultTmplFile checks the current working directory for *.nomad files.
+// If only 1 is found we return the match.
+func GetDefaultTmplFile() (templateFile string) {
+	if matches, _ := filepath.Glob("*.nomad"); matches != nil {
+		if len(matches) == 1 {
+			templateFile = matches[0]
+			logging.Debug("helper/files: using templatefile `%v`", templateFile)
+			return templateFile
+		}
+	}
+	return ""
+}
+
+// GetDefaultVarFile checks the current working directory for levant.(yaml|yml|tf) files.
+// The first match is returned.
+func GetDefaultVarFile() (varFile string) {
+	if _, err := os.Stat("levant.yaml"); !os.IsNotExist(err) {
+		logging.Debug("helper/files: using default var-file `levant.yaml`")
+		return "levant.yaml"
+	}
+	if _, err := os.Stat("levant.yml"); !os.IsNotExist(err) {
+		logging.Debug("helper/files: using default var-file `levant.yml`")
+		return "levant.yml"
+	}
+	if _, err := os.Stat("levant.tf"); !os.IsNotExist(err) {
+		logging.Debug("helper/files: using default var-file `levant.tf`")
+		return "levant.tf"
+	}
+	logging.Debug("helper/files: no default var-file found")
+	return ""
+}

--- a/levant/templater.go
+++ b/levant/templater.go
@@ -38,7 +38,6 @@ func RenderJob(templateFile, variableFile string, flagVars *map[string]string) (
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
 func RenderTemplate(templateFile, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
-
 	// Process the variable file extension and log DEBUG so the template can be
 	// correctly rendered.
 	ext := path.Ext(variableFile)

--- a/levant/templater.go
+++ b/levant/templater.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	terraformVarExtention = ".tf"
+	terraformVarExtension = ".tf"
 	yamlVarExtension      = ".yaml"
 	ymlVarExtension       = ".yml"
 )
@@ -38,6 +38,10 @@ func RenderJob(templateFile, variableFile string, flagVars *map[string]string) (
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
 func RenderTemplate(templateFile, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+	if variableFile == "" {
+		variableFile = helper.GetDefaultVarFile()
+	}
+
 	// Process the variable file extension and log DEBUG so the template can be
 	// correctly rendered.
 	ext := path.Ext(variableFile)
@@ -57,8 +61,8 @@ func RenderTemplate(templateFile, variableFile string, flagVars *map[string]stri
 	}
 
 	switch ext {
-	case terraformVarExtention:
-		// Run the render using variables formatted in Terraforms .tf extension.
+	case terraformVarExtension:
+		logging.Debug("levant/templater: detected .tf variable file extension")
 		tpl, err = renderTFTemplte(string(src), variableFile, flagVars)
 
 	case yamlVarExtension, ymlVarExtension:

--- a/levant/templater.go
+++ b/levant/templater.go
@@ -39,13 +39,16 @@ func RenderJob(templateFile, variableFile string, flagVars *map[string]string) (
 // passed variables file.
 func RenderTemplate(templateFile, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
 	if variableFile == "" {
-		variableFile = helper.GetDefaultVarFile()
+		logging.Debug("levant/templater: no variable file passed, trying defaults")
+		if variableFile = helper.GetDefaultVarFile(); variableFile != "" {
+			logging.Debug("levant/templater: found default variable file, using %s", variableFile)
+		}
 	}
 
 	// Process the variable file extension and log DEBUG so the template can be
 	// correctly rendered.
-	ext := path.Ext(variableFile)
-	if variableFile != "" {
+	var ext string
+	if ext = path.Ext(variableFile); ext != "" {
 		logging.Debug("levant/templater: variable file extension %s detected", ext)
 	}
 
@@ -62,15 +65,14 @@ func RenderTemplate(templateFile, variableFile string, flagVars *map[string]stri
 
 	switch ext {
 	case terraformVarExtension:
-		logging.Debug("levant/templater: detected .tf variable file extension")
 		tpl, err = renderTFTemplte(string(src), variableFile, flagVars)
 
 	case yamlVarExtension, ymlVarExtension:
-		// Run the render using a YAML varaible file.
+		// Run the render using a YAML variable file.
 		tpl, err = renderYAMLVarsTemplate(string(src), variableFile, flagVars)
 
 	case "":
-		// No varibles file passed; render using any passed CLI variables.
+		// No variables file passed; render using any passed CLI variables.
 		logging.Debug("levant/templater: variable file not passed")
 		tpl, err = readJobFile(string(src), flagVars)
 


### PR DESCRIPTION
  A basic way of implementing issue #10
  If no argument is given we check for the existence of a
  levant.nomad jobfile.

  If no -var-file is given we check for the existence of a
  levant.tf variable file.

  This "standardizes" the use of named files and makes pipelines
  clean in command usage.