### PR TITLE
Add tests for command/deploy.checkCanaryAutoPromote function.

### DIFF
--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/jrasell/levant/levant"
+)
+
+func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
+
+	fVars := make(map[string]string)
+	depCommand := &DeployCommand{}
+	canaryPromote := 30
+
+	cases := []struct {
+		File          string
+		CanaryPromote int
+		Output        error
+	}{
+		{
+			File:          "test-fixtures/job_canary.nomad",
+			CanaryPromote: canaryPromote,
+			Output:        nil,
+		},
+		{
+			File:          "test-fixtures/group_canary.nomad",
+			CanaryPromote: canaryPromote,
+			Output:        nil,
+		},
+	}
+
+	for i, c := range cases {
+		job, err := levant.RenderJob(c.File, "", &fVars)
+		if err != nil {
+			t.Fatalf("case %d failed: %v", i, err)
+		}
+
+		out := depCommand.checkCanaryAutoPromote(job, c.CanaryPromote)
+		if out != c.Output {
+			t.Fatalf("case %d: got \"%v\"; want %v", i, out, c.Output)
+		}
+	}
+}

--- a/command/test-fixtures/group_canary.nomad
+++ b/command/test-fixtures/group_canary.nomad
@@ -1,0 +1,56 @@
+job "example" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "cache" {
+    update {
+      max_parallel     = 1
+      min_healthy_time = "10s"
+      healthy_deadline = "1m"
+      auto_revert      = true
+      canary           = 1
+    }
+    count = 1
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay = "25s"
+      mode = "delay"
+    }
+    ephemeral_disk {
+      size = 300
+    }
+    task "redis" {
+      artifact {
+        source = "google.com"
+      }
+
+      driver = "docker"
+      config {
+        image = "redis:3.2"
+        port_map {
+          db = 6379
+        }
+      }
+      resources {
+        cpu    = 500
+        memory = 256
+        network {
+          mbits = 10
+          port "db" {}
+        }
+      }
+      service {
+        name = "global-redis-check"
+        tags = ["global", "cache"]
+        port = "db"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/command/test-fixtures/job_canary.nomad
+++ b/command/test-fixtures/job_canary.nomad
@@ -1,0 +1,55 @@
+job "example" {
+  datacenters = ["dc1"]
+  type = "service"
+  update {
+    max_parallel     = 1
+    min_healthy_time = "10s"
+    healthy_deadline = "1m"
+    auto_revert      = true
+    canary           = 1
+  }
+  group "cache" {
+    count = 1
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay = "25s"
+      mode = "delay"
+    }
+    ephemeral_disk {
+      size = 300
+    }
+    task "redis" {
+      artifact {
+        source = "google.com"
+      }
+
+      driver = "docker"
+      config {
+        image = "redis:3.2"
+        port_map {
+          db = 6379
+        }
+      }
+      resources {
+        cpu    = 500
+        memory = 256
+        network {
+          mbits = 10
+          port "db" {}
+        }
+      }
+      service {
+        name = "global-redis-check"
+        tags = ["global", "cache"]
+        port = "db"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit adds tests for command/deploy.checkCanaryAutoPromote
to ensure both job level and taskgroup level canary stanzas are
taking into account.

@pmcatominey this may be of interest in relation to your previous PR.