### PR TITLE
Nomad jobs of type batch do not produce evaluations.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -78,6 +78,12 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 		return
 	}
 
+	// GH-50: batch job types do not return an evaluation upon registration.
+	if eval == nil && *job.Type == nomadStructs.JobTypeBatch {
+		logging.Debug("levant/deploy: job type %s does not create evaluations", nomadStructs.JobTypeBatch)
+		return true
+	}
+
 	// Trigger the evaluationInspector to identify any potential errors in the
 	// Nomad evaluation run. As far as I can tell from testing; a single alloc
 	// failure in an evaluation means no allocs will be placed so we exit here.


### PR DESCRIPTION
Previously Levant would register the job and then check the return
for the eval_ID and thus continue with the deployment checking.
Nomad batch jobs do not produce an evaluation upon registration
and therefore would cause an error within Levant which was not
handled in the most appropriate manner. This change checks the job
type and eval return to properly catch batch job registrations and
log correct information.

In the future Levant should be updated to perform a basic running
check on batch jobs to provide further deployment feedback.

Closes #50