### PR TITLE
Levant can now track Nomad auto-revert of a failed deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Levant is an open source templating and deployment tool for [HashiCorp Nomad](ht
 
 * **Multiple Variable File Formats**: Currently Levant supports `.tf`, `.yaml` and `.yml` file extensions for the declaration of template variables. *This is planned to increase in the near future.*
 
+* **Auto Revert Checking**: In the event that a job deployment does not pass its healthy threshold and the job has auto-revert enabled; Levant will track the resulting rollback deployment so you can see the exact outcome of the deployment process.
+
 ## Download
 
 * The Levant binary can be downloaded from the [GitHub releases page]() using `curl https://github.com/jrasell/levant/releases/download/v0.0.1/linux-amd64-levant -o levant`

--- a/levant/auto_revert.go
+++ b/levant/auto_revert.go
@@ -1,0 +1,51 @@
+package levant
+
+import (
+	nomad "github.com/hashicorp/nomad/api"
+	"github.com/jrasell/levant/logging"
+)
+
+func (c *nomadClient) autoRevert(jobID *string) {
+
+	dep, _, err := c.nomad.Jobs().LatestDeployment(*jobID, nil)
+	if err != nil {
+		logging.Error("levant/auto_revert: unable to query latest deployment of job %s", *jobID)
+		return
+	}
+
+	logging.Info("levant/auto_revert: beginning deployment watcher for job %s", *jobID)
+	success := c.deploymentWatcher(dep.ID, 0)
+
+	if success {
+		logging.Info("levant/auto_revert: auto-revert of job %s was successful", *jobID)
+	} else {
+		logging.Error("levant/auto_revert: auto-revert of job %s failed; POTENTIAL OUTAGE SITUATION", *jobID)
+		c.checkFailedDeployment(&dep.ID)
+	}
+}
+
+// checkAutoRevert inspects a Nomad deployment to determine if any TashGroups
+// have been auto-reverted.
+func (c *nomadClient) checkAutoRevert(dep *nomad.Deployment) {
+
+	var revert bool
+
+	// Identify whether any of the TashGroups are enabled for auto-revert and have
+	// therefore caused the job to enter a deployment to revert to a stable
+	// version.
+	for _, v := range dep.TaskGroups {
+		if v.AutoRevert {
+			revert = true
+		}
+	}
+
+	if revert {
+		logging.Info("levant/auto_revert: job %v has entered auto-revert state; launching auto-revert checker",
+			dep.JobID)
+
+		// Run the levant autoRevert function.
+		c.autoRevert(&dep.JobID)
+	} else {
+		logging.Info("levant/auto_revert: job %v is not in auto-revert; POTENTIAL OUTAGE SITUATION", dep.JobID)
+	}
+}


### PR DESCRIPTION
As of Nomad 0.6 deployments supported auto-revert; whereby a job
would be reverted to its previous stable configuration if a
deployment was marked as failed. This change introduces the
ability for Levant to track the auto-revert deployment and log
realtime feedback. Levant will also print in CAPS if either a
revert fails or a deployment failed and is not configured to
revert so that users can make adjustments to their job in future
to avoid potential outage situations.

Closes #47