### PR TITLE
Update the Dockerfile to install ca-certificates for TLS envs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN apk add --no-cache make \
 
 FROM alpine:latest
 
+RUN apk add --no-cache ca-certificates
+
 COPY --from=builder /go/bin/levant /usr/bin/levant
 CMD ["levant", "--help"]


### PR DESCRIPTION
In particular setups using TLS, Levant will need the
ca-certificates package installed in order to make use of trusted
system CA certificates. Without this executing Levant results in
the error "failed to load system roots".