### PR TITLE
Update logging around passed variables and overridden variables.

### DIFF
--- a/helper/variable.go
+++ b/helper/variable.go
@@ -1,5 +1,7 @@
 package helper
 
+import "github.com/jrasell/levant/logging"
+
 // VariableMerge merges the passed file variables with the flag variabes to
 // provide a single set of variables. The flagVars will always prevale over file
 // variables.
@@ -8,13 +10,17 @@ func VariableMerge(fileVars *map[string]interface{}, flagVars *map[string]string
 	out := make(map[string]interface{})
 
 	for k, v := range *flagVars {
+		logging.Info("helper/variable: using command line variable with key %s and value %s", k, v)
 		out[k] = v
 	}
 
 	for k, v := range *fileVars {
 		if _, ok := out[k]; ok {
+			logging.Debug("helper/variable: variable from file with key %s and value %s overridden by CLI var",
+				k, v)
 			continue
 		}
+		logging.Info("helper/variable: using variable with key %s and value %v from file", k, v)
 		out[k] = v
 	}
 

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -49,7 +49,8 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 
 	// If job.Type isn't set we can't continue
 	if job.Type == nil {
-		logging.Error("levant/deploy: Nomad job `type` is not set, should be set to `service`")
+		logging.Error("levant/deploy: Nomad job `type` is not set; should be set to `%s`, `%s` or `%s`",
+			nomadStructs.JobTypeBatch, nomadStructs.JobTypeSystem, nomadStructs.JobTypeService)
 		return
 	}
 


### PR DESCRIPTION
This change adds some logging lines to provide greater feedback to
the user around variables file passed, CLI variables passed and
which variables are being used by Levant.

Closes #61