### PR TITLE
Fix issue where travis would run the release build every time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
 - make test
 after_success:
-- make release
+- if [[ -n "$TRAVIS_TAG" ]]; then make release; fi
 notifications:
   email: true
 deploy:


### PR DESCRIPTION
This commit updates the travis.yml to only run the release build
if it is a tagged release and not on every run.