### PR TITLE
added timestamp to logs

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -13,7 +13,7 @@ type Formatter struct {
 
 // Format builds the log desired log format.
 func (c *Formatter) Format(entry *log.Entry) ([]byte, error) {
-	return []byte(fmt.Sprintf("[%s] %s\n", strings.ToUpper(entry.Level.String()), entry.Message)), nil
+	return []byte(fmt.Sprintf("%s [%s] %s\n", entry.Time.Format("2006/01/02 15:04:05 MST"), strings.ToUpper(entry.Level.String()), entry.Message)), nil
 }
 
 func init() {


### PR DESCRIPTION
This addresses #68 
Note, that there are two types of log output in levant.  The first is from the UI and the second is from the various functions.  They UI uses a different logging mechanism (presumably so that they logs can be pointed to a file at somepoint while still maintaining some meaningful command output).   This only changes the function output not the UI output.  I can modify the UI output as well if you like.