### PR TITLE
levant/deploy: skip health checks for task groups without canaries

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -321,6 +321,12 @@ func (c *nomadClient) checkCanaryDeploymentHealth(depID string) (healthy bool) {
 	// Itertate each task in the deployment to determine is health status. If an
 	// unhealthy task is found, incrament the unhealthy counter.
 	for taskName, taskInfo := range dep.TaskGroups {
+		// skip any task groups which are not configured for canary deployments
+		if taskInfo.DesiredCanaries == 0 {
+			logging.Debug("levant/deploy: task %s has no desired canaries, skipping health checks in deployment %s", taskName, depID)
+			continue
+		}
+
 		if taskInfo.DesiredCanaries != taskInfo.HealthyAllocs {
 			logging.Error("levant/deploy: task %s has unhealthy allocations in deployment %s", taskName, depID)
 			unhealthy++


### PR DESCRIPTION
if a job contains at least one task group with canary deployments configured
and at least one without, the deployment watcher will fail the deployment
as the check for healthy canaries assumed every task group is configured for
canary deployments.

Tested with `levant deploy -canary-auto-promote 30 echo.nomad` and the following Job specification (add/remove `:latest` to the image argument to trigger a deployment):
```
job "echo" {
  datacenters = ["dc1"]
  type = "service"

  group "echo-canary" {
    count = 2

    update {
      canary       = 2
      max_parallel = 2
    }

    task "echo-canary" {
      driver = "docker"
      config {
        image = "alpine"
        command = "tail"
        args = ["-f", "/dev/null"]
      }
    }
  }

  group "echo-standard" {
    count = 1

    update {
      max_parallel = 1
    }

    task "echo-standard" {
      driver = "docker"
      config {
        image = "alpine"
        command = "tail"
        args = ["-f", "/dev/null"]
      }
    }
  }
}
```