### PR TITLE
added in the ability to monitor batch jobs to completion - WIP

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -18,7 +18,7 @@ type nomadClient struct {
 type NomadClient interface {
 	// Deploy triggers a register of the job resulting in a Nomad deployment which
 	// is monitored to determine the eventual state.
-	Deploy(*nomad.Job, int, bool) bool
+	Deploy(*nomad.Job, int, bool, uint64, bool) bool
 }
 
 // NewNomadClient is used to create a new client to interact with Nomad.

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -18,7 +18,7 @@ type nomadClient struct {
 type NomadClient interface {
 	// Deploy triggers a register of the job resulting in a Nomad deployment which
 	// is monitored to determine the eventual state.
-	Deploy(*nomad.Job, int, bool) bool
+	Deploy(*nomad.Job, int, bool, uint64, bool) bool
 }
 
 // NewNomadClient is used to create a new client to interact with Nomad.
@@ -39,7 +39,7 @@ func NewNomadClient(addr string) (NomadClient, error) {
 
 // Deploy triggers a register of the job resulting in a Nomad deployment which
 // is monitored to determine the eventual state.
-func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (success bool) {
+func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool, timeout uint64, monitor bool) (success bool) {
 
 	// Validate the job to check it is syntactically correct.
 	if _, _, err := c.nomad.Jobs().Validate(job, nil); err != nil {
@@ -83,9 +83,11 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 		return
 	}
 
-	// GH-50: batch job types do not return an evaluation upon registration.
-	if eval.EvalID == "" && *job.Type == nomadStructs.JobTypeBatch {
-		return c.checkBatchJob(job.Name)
+	// parameterized jobs don't generate an eval until they run.  So if we have a succesful insertion
+	// we are done and happy.
+	if job.IsParameterized() {
+		logging.Info("levant/deploy: registered paramaterized job %s with Nomad.", *job.Name)
+		return
 	}
 
 	// Trigger the evaluationInspector to identify any potential errors in the
@@ -123,6 +125,14 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 			}
 			c.checkAutoRevert(dep)
 		}
+	case nomadStructs.JobTypeBatch:
+		logging.Info("levant/deploy: beginning batch watcher for job %s", *job.Name)
+		// periodic jobs never run to completion so attempting to monitor them will fail
+		if job.IsPeriodic() && monitor {
+			logging.Error("levant/deploy: cannot use the --monitor flag with periodic job %s.", *job.Name)
+			return
+		}
+		return c.checkBatchJob(&eval.EvalID, timeout, monitor)
 
 	default:
 		logging.Debug("levant/deploy: job type %s does not support Nomad deployment model", *job.Type)

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -1,6 +1,7 @@
 package levant
 
 import (
+	"sync"
 	"time"
 
 	nomad "github.com/hashicorp/nomad/api"
@@ -8,46 +9,158 @@ import (
 	"github.com/jrasell/levant/logging"
 )
 
-// checkBatchJob checks the status of a batch job at least reaches a status of
-// running. This is required as currently Nomad does not support deployments of
-// job type batch.
-func (c *nomadClient) checkBatchJob(jobName *string) bool {
+// checkBatchJob checks that the status of a batch job at least reaches a status of
+// running. It can, optionally, monitor a job until it has finished as well.  This
+// is required as currently Nomad does not support deployments of job type batch.
+// Parameters:
+// monitor - whether to follow the task to completion or only to insertion
+// timeout - how long to wait until we fail the task
+func (c *nomadClient) checkBatchJob(evalID *string, timeoutSeconds uint64, monitor bool) bool {
+	// set some timeouts
+	timeout := time.Tick(time.Second * time.Duration(timeoutSeconds))
+	// close this to stop the job monitor
+	finish := make(chan bool)
+	defer close(finish)
+	// set up some communication channels
+	jobChan := make(chan *nomad.Job, 1)
+	errChan := make(chan error, 1)
 
-	// Initialiaze our WaitIndex
-	var wi uint64
+	// get the evaluation
+	eval, _, err := c.nomad.Evaluations().Info(*evalID, nil)
+	if err != nil {
+		logging.Error("levant/deploy: unable to get info of evaluation %s: %v", eval.ID, err)
+		return false
+	}
 
-	// Setup the Nomad QueryOptions to allow blocking query and a timeout.
-	q := &nomad.QueryOptions{WaitIndex: wi}
-	timeout := time.Tick(time.Minute * 5)
+	// get the job name
+	jobName := eval.JobID
+
+	// start our monitor
+	go c.monitorJobInfo(jobName, jobChan, errChan, finish)
 
 	for {
-
-		job, meta, err := c.nomad.Jobs().Info(*jobName, q)
-		if err != nil {
-			logging.Error("levant/job_status_checker: unable to query batch job %s: %v", *jobName, err)
-			return false
-		}
-
-		// If the LastIndex is not greater than our stored LastChangeIndex, we don't
-		// need to do anything.
-		if meta.LastIndex <= wi {
-			continue
-		}
-
-		if *job.Status == nomadStructs.JobStatusRunning {
-			logging.Info("levant/job_status_checker: batch job %s has status %s", *jobName, *job.Status)
-			return true
-		}
-
 		select {
 		case <-timeout:
-			logging.Error("levant/job_status_checker: timeout reached while verifying the status of batch job %s",
-				*jobName)
+			logging.Error("levant/job_status_checker: timeout reached while verifying the status of batch job %s", jobName)
+			// run the allocation inspector
+			var allocIDS []string
+			// get some additional information about the exit of the job
+			allocs, _, err := c.nomad.Evaluations().Allocations(*evalID, nil)
+			if err != nil {
+				logging.Error("levant/log_status_checker: unable to get allocations from evaluation %s: %v", evalID, err)
+				return false
+			}
+			// check to see if any of our allocations failed
+			for _, alloc := range allocs {
+				logging.Info("hello")
+				for _, task := range alloc.TaskStates {
+					// we need to test for success
+					if task.State != nomadStructs.TaskStarted {
+						allocIDS = append(allocIDS, alloc.ID)
+						// once we add the allocation we don't need to add it again
+						break
+					}
+				}
+			}
+
+			c.inspectAllocs(allocIDS)
 			return false
-		default:
-			logging.Debug("levant/job_status_checker: batch job %s currently has status %s", *jobName, *job.Status)
-			q.WaitIndex = meta.LastIndex
-			continue
+		case err = <-errChan:
+			logging.Error("levant/job_status_checker: unable to query batch job %s: %v", jobName, err)
+			logging.Error("Retrying...")
+
+		case job := <-jobChan:
+			// depending on the state of the job we do different things
+			switch *job.Status {
+			// if the job is stopped then we take some action depending on why it stopped
+			case nomadStructs.JobStatusDead:
+				var allocIDS []string
+				// get some additional information about the exit of the job
+				allocs, _, err := c.nomad.Evaluations().Allocations(*evalID, nil)
+				if err != nil {
+					logging.Error("levant/log_status_checker: unable to get allocations from evaluation %s: %v", evalID, err)
+					return false
+				}
+				// check to see if any of our allocations failed
+				for _, alloc := range allocs {
+					for _, task := range alloc.TaskStates {
+						if task.Failed {
+							allocIDS = append(allocIDS, alloc.ID)
+						}
+					}
+				}
+				if len(allocIDS) > 0 {
+					c.inspectAllocs(allocIDS)
+					return false
+				} else {
+					// otherwise we just return true
+					return true
+				}
+			case nomadStructs.JobStatusRunning:
+				logging.Info("levant/job_status_checker: batch job %s has status %s", jobName, *job.Status)
+				// if we are not set to wait until the job is done then we exit
+				// additionally, regardless of whether we are set to wait, periodic jobs always exit on running
+				if !monitor || job.IsPeriodic() {
+					return true
+				}
+			default:
+				logging.Debug("levant/job_status_checker: got job state %s.  Don't know what to do with that.", *job.Status)
+			}
 		}
+	}
+}
+
+// monitorJobInfo will get information on a job from nomad and returns the information on channels
+// once it has updated
+func (c *nomadClient) monitorJobInfo(jobName string, jobChan chan<- *nomad.Job, errChan chan<- error, done chan bool) {
+
+	// Setup the Nomad QueryOptions to allow blocking query and a timeout.
+	q := &nomad.QueryOptions{WaitIndex: 0, WaitTime: time.Second * 10}
+
+	for {
+		select {
+		case <-done:
+			// allow us to exit on demand (technically, it will still need to wait for the namad query to return)
+			return
+		default:
+			// get our job info
+			job, meta, err := c.nomad.Jobs().Info(jobName, q)
+			if err != nil {
+				errChan <- err
+				// sleep a bit before retrying
+				time.Sleep(time.Second * 5)
+				continue
+			}
+			logging.Info("lastIndex: %v", meta.LastIndex)
+			// only take action if the informaiton has changed
+			if meta.LastIndex > q.WaitIndex {
+				q.WaitIndex = meta.LastIndex
+				jobChan <- job
+			} else {
+				// log a debug message
+				logging.Debug("levant/job_status_checker: batch job %s currently has status %s", jobName, *job.Status)
+			}
+		}
+	}
+}
+
+// inspectAllocs is a helper function that will call the allocInspector for each of the provided allocations
+// and return when it has completed
+func (c *nomadClient) inspectAllocs(allocs []string) {
+	// if we have failed allocations than we print information about them
+	if len(allocs) > 0 {
+		// we want to run throuh and get messages for all of our failed allocations in parallel
+		var wg sync.WaitGroup
+		wg.Add(+len(allocs))
+
+		// Inspect each allocation.
+		for _, id := range allocs {
+			logging.Debug("levant/failure_inspector: launching allocation inspector for alloc %v", id)
+			go c.allocInspector(id, &wg)
+		}
+
+		// wait until our allocations have printed messages
+		wg.Wait()
+		return
 	}
 }


### PR DESCRIPTION
Also, fixed handling of periodic and paramaterized jobs.
Also added in a --timeout flag so that levant can terminate if the job takes too long.