### PR TITLE
Fix issue where jobs without specified count caused panic.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -61,20 +61,6 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 		}
 	}
 
-	// Check that the job has at least 1 TaskGroup with count > 0 (GH-16) if the
-	// job is not a System job. Systems jobs do not define counts so cannot be
-	// checked.
-	if *job.Type != nomadStructs.JobTypeSystem {
-		tgCount := 0
-		for _, group := range job.TaskGroups {
-			tgCount += *group.Count
-		}
-		if tgCount == 0 {
-			logging.Error("levant/deploy: all TaskGroups have a count of 0, nothing to do")
-			return
-		}
-	}
-
 	logging.Info("levant/deploy: triggering a deployment of job %s", *job.Name)
 
 	eval, _, err := c.nomad.Jobs().Register(job, nil)


### PR DESCRIPTION
This issue was caused by the incorrect assumption that jobs with a count not set or set to 0 can not result in a deployment. This was incorrect as an undefined count will result in a default count of 1; or that jobs set to count=0 can be run and deployed to stage the job or disable it.

@mimato and @adamlc this should fix the issue you're seeing and also fixes previously unseen bugs in the deployment process. It has been tested with the following suite of jobs:
* service with count 1
* service with count 0
* service with count undefined
* batch with count undefined
* batch with count 1

Closes #87 