### PR TITLE
Levant can now confirm jobs with type system reach running state.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -111,10 +111,13 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 		}
 
 	case nomadStructs.JobTypeBatch:
-		return c.checkBatchJob(job.Name)
+		return c.checkJobStatus(job.Name)
+
+	case nomadStructs.JobTypeSystem:
+		return c.checkJobStatus(job.Name)
 
 	default:
-		logging.Debug("levant/deploy: job type %s does not support Nomad deployment model", *job.Type)
+		logging.Debug("levant/deploy: Levant does not support advanced deployments of job type %s", *job.Type)
 		success = true
 	}
 	return

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -8,10 +8,12 @@ import (
 	"github.com/jrasell/levant/logging"
 )
 
-// checkBatchJob checks the status of a batch job at least reaches a status of
-// running. This is required as currently Nomad does not support deployments of
-// job type batch.
-func (c *nomadClient) checkBatchJob(jobName *string) bool {
+// checkJobStatus checks the status of a job at least reaches a status of
+// running. This is required as currently Nomad does not support deployments
+// across all job types.
+func (c *nomadClient) checkJobStatus(jobName *string) bool {
+
+	logging.Info("levant/job_status_checker: running job status checker for %s", *jobName)
 
 	// Initialiaze our WaitIndex
 	var wi uint64
@@ -35,17 +37,17 @@ func (c *nomadClient) checkBatchJob(jobName *string) bool {
 		}
 
 		if *job.Status == nomadStructs.JobStatusRunning {
-			logging.Info("levant/job_status_checker: batch job %s has status %s", *jobName, *job.Status)
+			logging.Info("levant/job_status_checker: job %s has status %s", *jobName, *job.Status)
 			return true
 		}
 
 		select {
 		case <-timeout:
-			logging.Error("levant/job_status_checker: timeout reached while verifying the status of batch job %s",
+			logging.Error("levant/job_status_checker: timeout reached while verifying the status of job %s",
 				*jobName)
 			return false
 		default:
-			logging.Debug("levant/job_status_checker: batch job %s currently has status %s", *jobName, *job.Status)
+			logging.Debug("levant/job_status_checker: job %s currently has status %s", *jobName, *job.Status)
 			q.WaitIndex = meta.LastIndex
 			continue
 		}


### PR DESCRIPTION
In the same manner that batch jobs are checked to ensure they
reach the running state; system type jobs will now go through the
same process.

Closes #92