### PR TITLE
Check that service jobs have an update stanza.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -85,6 +85,15 @@ func (c *nomadClient) Deploy(job *nomad.Job, autoPromote int, forceCount bool) (
 
 	switch *job.Type {
 	case nomadStructs.JobTypeService:
+
+		// If the service job doesn't have an update stanza, the job will not use
+		// Nomad deployments.
+		if job.Update == nil {
+			logging.Info("levant/deploy: job %s is not configured with update stanza, consider adding to use deployments",
+				*job.Name)
+			return c.checkJobStatus(job.Name)
+		}
+
 		logging.Info("levant/deploy: beginning deployment watcher for job %s", *job.Name)
 
 		// Get the deploymentID from the evaluationID so that we can watch the


### PR DESCRIPTION
If a service job is not configured with an update stanza, no Nomad
deployment will occur. Therefore Levant must skip the deploy and
use the generic job status checker function otherwise it will
error trying to find a deployment assosiated to the register.

Closes #90