### PR TITLE
Implement config struct for Levant to track config during run.

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Meta contains the meta-options and functionality that nearly every
-// Packer command inherits.
+// Levant command inherits.
 type Meta struct {
 	UI cli.Ui
 

--- a/levant/auto_revert.go
+++ b/levant/auto_revert.go
@@ -5,28 +5,28 @@ import (
 	"github.com/jrasell/levant/logging"
 )
 
-func (c *nomadClient) autoRevert(jobID *string) {
+func (l *levantDeployment) autoRevert(jobID *string) {
 
-	dep, _, err := c.nomad.Jobs().LatestDeployment(*jobID, nil)
+	dep, _, err := l.nomad.Jobs().LatestDeployment(*jobID, nil)
 	if err != nil {
 		logging.Error("levant/auto_revert: unable to query latest deployment of job %s", *jobID)
 		return
 	}
 
 	logging.Info("levant/auto_revert: beginning deployment watcher for job %s", *jobID)
-	success := c.deploymentWatcher(dep.ID, 0)
+	success := l.deploymentWatcher(dep.ID)
 
 	if success {
 		logging.Info("levant/auto_revert: auto-revert of job %s was successful", *jobID)
 	} else {
 		logging.Error("levant/auto_revert: auto-revert of job %s failed; POTENTIAL OUTAGE SITUATION", *jobID)
-		c.checkFailedDeployment(&dep.ID)
+		l.checkFailedDeployment(&dep.ID)
 	}
 }
 
 // checkAutoRevert inspects a Nomad deployment to determine if any TashGroups
 // have been auto-reverted.
-func (c *nomadClient) checkAutoRevert(dep *nomad.Deployment) {
+func (l *levantDeployment) checkAutoRevert(dep *nomad.Deployment) {
 
 	var revert bool
 
@@ -44,7 +44,7 @@ func (c *nomadClient) checkAutoRevert(dep *nomad.Deployment) {
 			dep.JobID)
 
 		// Run the levant autoRevert function.
-		c.autoRevert(&dep.JobID)
+		l.autoRevert(&dep.JobID)
 	} else {
 		logging.Info("levant/auto_revert: job %v is not in auto-revert; POTENTIAL OUTAGE SITUATION", dep.JobID)
 	}

--- a/levant/failure_inspector.go
+++ b/levant/failure_inspector.go
@@ -11,11 +11,11 @@ import (
 )
 
 // checkFailedDeployment helps log information about deployment failures.
-func (c *nomadClient) checkFailedDeployment(depID *string) {
+func (l *levantDeployment) checkFailedDeployment(depID *string) {
 
 	var allocIDS []string
 
-	allocs, _, err := c.nomad.Deployments().Allocations(*depID, nil)
+	allocs, _, err := l.nomad.Deployments().Allocations(*depID, nil)
 	if err != nil {
 		logging.Error("levant/failure_inspector: unable to query deployment allocations for deployment %s",
 			depID)
@@ -37,7 +37,7 @@ func (c *nomadClient) checkFailedDeployment(depID *string) {
 	// Inspect each allocation.
 	for _, id := range allocIDS {
 		logging.Debug("levant/failure_inspector: launching allocation inspector for alloc %v", id)
-		go c.allocInspector(id, &wg)
+		go l.allocInspector(id, &wg)
 	}
 
 	wg.Wait()
@@ -45,12 +45,12 @@ func (c *nomadClient) checkFailedDeployment(depID *string) {
 
 // allocInspector inspects an allocations events to log any useful information
 // which may help debug deployment failures.
-func (c *nomadClient) allocInspector(allocID string, wg *sync.WaitGroup) {
+func (l *levantDeployment) allocInspector(allocID string, wg *sync.WaitGroup) {
 
 	// Inform the wait group we have finished our task upon completion.
 	defer wg.Done()
 
-	resp, _, err := c.nomad.Allocations().Info(allocID, nil)
+	resp, _, err := l.nomad.Allocations().Info(allocID, nil)
 	if err != nil {
 		logging.Error("levant/failure_inspector: unable to query alloc %v: %v", allocID, err)
 		return

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -1,0 +1,33 @@
+package structs
+
+import nomad "github.com/hashicorp/nomad/api"
+
+// Config is the main struct used to configure and run a Levant deployment on
+// a given target job.
+type Config struct {
+	// Addr is the Nomad API address to use for all calls and must include both
+	// protocol and port.
+	Addr string
+
+	// Canary enables canary autopromote and is the value in seconds to wait
+	// until attempting to perfrom autopromote.
+	Canary int
+
+	// ForceCount is a boolean flag that can be used to ignore running job counts
+	// and force the count based on the rendered job file.
+	ForceCount bool
+
+	// Job represents the Nomad Job definition that will be deployed.
+	Job *nomad.Job
+
+	// LogLevel is the level at which Levant will log.
+	LogLevel string
+
+	// TemplateFile is the job specification template which will be rendered
+	// before being deployed to the cluster.
+	TemplateFile string
+
+	// VaiableFile contains the variables which will be substituted into the
+	// templateFile before deployment.
+	VaiableFile string
+}


### PR DESCRIPTION
This commit adds a config struct to Levant which is used during
every Levant invoction. This allows for easier tracking of info
and also easier future extensibility.

Closes #95