### PR TITLE
Enhanced job status checking for non-service type jobs.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -127,7 +127,7 @@ func (l *levantDeployment) deploy() (success bool) {
 		if l.config.Job.Update == nil {
 			logging.Info("levant/deploy: job %s is not configured with update stanza, consider adding to use deployments",
 				*l.config.Job.Name)
-			return l.checkJobStatus()
+			return l.jobStatusChecker(&eval.EvalID)
 		}
 
 		logging.Info("levant/deploy: beginning deployment watcher for job %s", *l.config.Job.Name)
@@ -156,10 +156,10 @@ func (l *levantDeployment) deploy() (success bool) {
 		}
 
 	case nomadStructs.JobTypeBatch:
-		return l.checkJobStatus()
+		return l.jobStatusChecker(&eval.EvalID)
 
 	case nomadStructs.JobTypeSystem:
-		return l.checkJobStatus()
+		return l.jobStatusChecker(&eval.EvalID)
 
 	default:
 		logging.Debug("levant/deploy: Levant does not support advanced deployments of job type %s",

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -1,56 +1,209 @@
 package levant
 
 import (
-	"time"
-
 	nomad "github.com/hashicorp/nomad/api"
 	nomadStructs "github.com/hashicorp/nomad/nomad/structs"
 	"github.com/jrasell/levant/logging"
 )
 
-// checkJobStatus checks the status of a job at least reaches a status of
-// running. This is required as currently Nomad does not support deployments
-// across all job types.
-func (l *levantDeployment) checkJobStatus() bool {
+// initialTaskHealth is the Levant health status assosiated to a Task when it is
+// initially discovered as part of the deployment.
+const initialTaskHealth = "unknown"
+
+// jobStatusChecker checks the status of a job at least reaches a status of
+// running. Depending on the type of job and its configuration it can go through
+// more checks.
+func (l *levantDeployment) jobStatusChecker(evalID *string) bool {
+
+	logging.Debug("levant/job_status_checker: running job status checker for job %s",
+		*l.config.Job.Name)
+
+	// Run the initial job status check to ensure the job reaches a state of
+	// running.
+	jStatus := l.simpleJobStatusChecker(*l.config.Job.ID)
+
+	// Periodic and parameterized batch jobs do not produce evaluations and so
+	// can only go through the simplest of checks.
+	if *evalID == "" {
+		return jStatus
+	}
+
+	// Job registrations that produce an evaluation can be more thoroughly
+	// checked even if they don't support Nomad deployments.
+	if jStatus {
+		return l.jobAllocationChecker(evalID)
+	}
+
+	return false
+}
+
+// simpleJobStatusChecker is used to check that jobs which do not emit initial
+// evaluations at least reach a job status of running.
+func (l *levantDeployment) simpleJobStatusChecker(jobID string) bool {
 
 	j := l.config.Job.Name
-	logging.Info("levant/job_status_checker: running job status checker for %s", *j)
-
-	// Initialiaze our WaitIndex
-	var wi uint64
-
-	// Setup the Nomad QueryOptions to allow blocking query and a timeout.
-	q := &nomad.QueryOptions{WaitIndex: wi}
-	timeout := time.Tick(time.Minute * 5)
+	q := &nomad.QueryOptions{WaitIndex: 1}
 
 	for {
 
 		job, meta, err := l.nomad.Jobs().Info(*j, q)
 		if err != nil {
-			logging.Error("levant/job_status_checker: unable to query batch job %s: %v", *j, err)
+			logging.Error("levant/job_status_checker: unable to query job %s: %v", *j, err)
 			return false
 		}
 
 		// If the LastIndex is not greater than our stored LastChangeIndex, we don't
 		// need to do anything.
-		if meta.LastIndex <= wi {
+		if meta.LastIndex <= q.WaitIndex {
 			continue
 		}
 
-		if *job.Status == nomadStructs.JobStatusRunning {
+		// Checks the status of the job and proceed as expected depending on this.
+		switch *job.Status {
+		case nomadStructs.JobStatusRunning:
 			logging.Info("levant/job_status_checker: job %s has status %s", *j, *job.Status)
 			return true
-		}
-
-		select {
-		case <-timeout:
-			logging.Error("levant/job_status_checker: timeout reached while verifying the status of job %s",
-				*j)
-			return false
-		default:
-			logging.Debug("levant/job_status_checker: job %s currently has status %s", *j, *job.Status)
+		case nomadStructs.JobStatusPending:
 			q.WaitIndex = meta.LastIndex
 			continue
+		case nomadStructs.JobStatusDead:
+			logging.Error("levant/job_status_checker: job %s has status %s", *j, *job.Status)
+			return false
+		}
+	}
+}
+
+// jobAllocationChecker is the main entry point into the allocation checker for
+// jobs that do not support Nomad deployments.
+func (l *levantDeployment) jobAllocationChecker(evalID *string) bool {
+
+	// Track if we experience any dead tasks in a dumb way.
+	var deadTasks int
+
+	j := l.config.Job.Name
+	q := &nomad.QueryOptions{WaitIndex: 1}
+
+	// Build our small internal checking struct.
+	levantTasks := l.buildAllocationChecker(evalID)
+
+	for {
+
+		allocs, meta, err := l.nomad.Evaluations().Allocations(*evalID, q)
+		if err != nil {
+			logging.Error("levant/job_status_checker: unable to query allocs of job %s: %v",
+				*j, err)
+			return false
+		}
+
+		// If the LastIndex is not greater than our stored LastChangeIndex, we don't
+		// need to do anything.
+		if meta.LastIndex <= q.WaitIndex {
+			continue
+		}
+
+		// If we get here, set the wi to the latest Index.
+		q.WaitIndex = meta.LastIndex
+
+		allocationStatusChecker(levantTasks, allocs, &deadTasks)
+
+		// If we have no allocations left to track then we can exit and log
+		// information depending on the success.
+		if len(levantTasks) == 0 && deadTasks == 0 {
+			logging.Info("levant/job_status_checker: all allocations in deployment of job %s are running", *j)
+			return true
+		} else if len(levantTasks) == 0 && deadTasks > 0 {
+			return false
+		}
+	}
+}
+
+func (l *levantDeployment) buildAllocationChecker(evalID *string) map[string]map[string]string {
+
+	// Create our map to track allocations and tasks within the evaluation created
+	// by the job registration.
+	levantTasks := make(map[string]map[string]string)
+
+	q := &nomad.QueryOptions{WaitIndex: 1}
+
+	// We use a for loop here as, during testing, I have observed Levant runs
+	// faster than Nomad and so without a blocking query a pure GET request can
+	// trigger before Nomad builds the allocation.
+	for {
+
+		// Pull the latest information abou the evaluation allocations from Nomad.
+		allocs, meta, err := l.nomad.Evaluations().Allocations(*evalID, q)
+		if err != nil {
+			logging.Error("levant/job_status_checker: unable to query evaluation for allocations: %v", err)
+			return nil
+		}
+
+		// If the LastIndex is not greater than our stored LastChangeIndex, we don't
+		// need to do anything.
+		if meta.LastIndex <= q.WaitIndex {
+			continue
+		}
+
+		// If we get here, set the wi to the latest Index.
+		q.WaitIndex = meta.LastIndex
+
+		// Iterate over each allocation which can contain multiple tasks in order to
+		// build our object of tasks to check.
+		for _, alloc := range allocs {
+			for taskName := range alloc.TaskStates {
+
+				// If we have not seen the allocation previously we need to init the map.
+				if levantTasks[alloc.ID] == nil {
+					levantTasks[alloc.ID] = make(map[string]string)
+				}
+
+				// Set the task health to our initial status of Unknown.
+				levantTasks[alloc.ID][taskName] = initialTaskHealth
+			}
+		}
+
+		if len(levantTasks) == 0 {
+			continue
+		}
+
+		return levantTasks
+	}
+}
+
+// allocationStatusChecker is used to check the state of allocations within a
+// job deployment, an update Levants internal tracking on task status based on
+// this. This functionality exists as Nomad does not currently support
+// deployments across all job types.
+func allocationStatusChecker(levantTasks map[string]map[string]string, allocs []*nomad.AllocationListStub, deadTask *int) {
+
+	for _, alloc := range allocs {
+		for taskName, task := range alloc.TaskStates {
+			levantTasks[alloc.ID][taskName] = task.State
+
+			// If the task is running, remove it from tracking.
+			switch levantTasks[alloc.ID][taskName] {
+			case nomadStructs.TaskStateRunning:
+				logging.Info("levant/job_status_checker: task %s in allocation %s has reached %s state",
+					taskName, alloc.ID, nomadStructs.TaskStateRunning)
+				delete(levantTasks[alloc.ID], taskName)
+
+			case nomadStructs.TaskStatePending:
+				logging.Debug("levant/job_status_checker: task %s in allocation %s now in running state",
+					taskName, alloc.ID)
+
+			// If the task is dead, incrament the deadTask counter and remove the task
+			// from tracking.
+			case nomadStructs.TaskStateDead:
+				logging.Error("levant/job_status_checker: task %s in allocation %s now in dead state",
+					taskName, alloc.ID)
+				*deadTask++
+				delete(levantTasks[alloc.ID], taskName)
+			}
+
+			// If we have no tasks left under the allocation to track remove the
+			// allocation from our tracker.
+			if len(levantTasks[alloc.ID]) == 0 {
+				delete(levantTasks, alloc.ID)
+			}
 		}
 	}
 }

--- a/levant/job_status_checker_test.go
+++ b/levant/job_status_checker_test.go
@@ -1,0 +1,92 @@
+package levant
+
+import (
+	"testing"
+
+	nomad "github.com/hashicorp/nomad/api"
+	nomadStructs "github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestJobStatusChecker_allocationStatusChecker(t *testing.T) {
+
+	// Setup our LevantTask structures.
+	levantTasks1 := make(map[string]map[string]string)
+	levantTasks1["10246d87-ecd7-21ad-13b2-f0c564647d64"] = make(map[string]string)
+	levantTasks1["10246d87-ecd7-21ad-13b2-f0c564647d64"]["task1"] = initialTaskHealth
+
+	levantTasks2 := make(map[string]map[string]string)
+	levantTasks2["20246d87-ecd7-21ad-13b2-f0c564647d64"] = make(map[string]string)
+	levantTasks2["20246d87-ecd7-21ad-13b2-f0c564647d64"]["task1"] = initialTaskHealth
+	levantTasks2["20246d87-ecd7-21ad-13b2-f0c564647d64"]["task2"] = initialTaskHealth
+
+	levantTasks3 := make(map[string]map[string]string)
+	levantTasks3["30246d87-ecd7-21ad-13b2-f0c564647d64"] = make(map[string]string)
+	levantTasks3["30246d87-ecd7-21ad-13b2-f0c564647d64"]["task1"] = initialTaskHealth
+
+	// Build a small AllocationListStubs with required information.
+	var allocs1 []*nomad.AllocationListStub
+	taskStates1 := make(map[string]*nomad.TaskState)
+	taskStates1["task1"] = &nomad.TaskState{State: nomadStructs.TaskStateRunning}
+	allocs1 = append(allocs1, &nomad.AllocationListStub{
+		ID:         "10246d87-ecd7-21ad-13b2-f0c564647d64",
+		TaskStates: taskStates1,
+	})
+
+	var allocs2 []*nomad.AllocationListStub
+	taskStates2 := make(map[string]*nomad.TaskState)
+	taskStates2["task1"] = &nomad.TaskState{State: nomadStructs.TaskStateRunning}
+	taskStates2["task2"] = &nomad.TaskState{State: nomadStructs.TaskStatePending}
+	allocs2 = append(allocs2, &nomad.AllocationListStub{
+		ID:         "20246d87-ecd7-21ad-13b2-f0c564647d64",
+		TaskStates: taskStates2,
+	})
+
+	var allocs3 []*nomad.AllocationListStub
+	taskStates3 := make(map[string]*nomad.TaskState)
+	taskStates3["task1"] = &nomad.TaskState{State: nomadStructs.TaskStateDead}
+	allocs3 = append(allocs3, &nomad.AllocationListStub{
+		ID:         "30246d87-ecd7-21ad-13b2-f0c564647d64",
+		TaskStates: taskStates3,
+	})
+
+	cases := []struct {
+		levantTasks    map[string]map[string]string
+		allocs         []*nomad.AllocationListStub
+		dead           int
+		expectedDead   int
+		expectedAllocs int
+	}{
+		{
+			levantTasks1,
+			allocs1,
+			0,
+			0,
+			0,
+		},
+		{
+			levantTasks2,
+			allocs2,
+			0,
+			0,
+			1,
+		},
+		{
+			levantTasks3,
+			allocs3,
+			0,
+			1,
+			0,
+		},
+	}
+
+	for _, tc := range cases {
+		allocationStatusChecker(tc.levantTasks, tc.allocs, &tc.dead)
+
+		if len(tc.levantTasks) != tc.expectedAllocs {
+			t.Fatalf("expected %v but got %v", tc.expectedAllocs, len(tc.levantTasks))
+		}
+		if tc.dead != tc.expectedDead {
+			t.Fatalf("expected %v dead task(s) but got %v", tc.expectedDead, tc.dead)
+		}
+	}
+}


### PR DESCRIPTION
Jobs that do not currently use Nomad deployments now go through
additional checks to provide better feedback regarding their end
state. This includes checking the job status, and any allocations
which were part of the job registration.

Closes #97