### PR TITLE
Add 'force-batch' deploy flag to allow force run of periodic job.

### DIFF
--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -41,3 +41,34 @@ func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 		}
 	}
 }
+
+func TestDeploy_checkForceBatch(t *testing.T) {
+
+	fVars := make(map[string]string)
+	depCommand := &DeployCommand{}
+	forceBatch := true
+
+	cases := []struct {
+		File       string
+		ForceBatch bool
+		Output     error
+	}{
+		{
+			File:       "test-fixtures/periodic_batch.nomad",
+			ForceBatch: forceBatch,
+			Output:     nil,
+		},
+	}
+
+	for i, c := range cases {
+		job, err := levant.RenderJob(c.File, "", &fVars)
+		if err != nil {
+			t.Fatalf("case %d failed: %v", i, err)
+		}
+
+		out := depCommand.checkForceBatch(job, c.ForceBatch)
+		if out != c.Output {
+			t.Fatalf("case %d: got \"%v\"; want %v", i, out, c.Output)
+		}
+	}
+}

--- a/command/test-fixtures/periodic_batch.nomad
+++ b/command/test-fixtures/periodic_batch.nomad
@@ -1,0 +1,25 @@
+job "periodic_batch_test" {
+  datacenters = ["dc1"]
+  region      = "global"
+  type        = "batch"
+  priority    = 75
+  periodic {
+    cron             = "* 1 * * * *"
+    prohibit_overlap = true
+  }
+  group "periodic_batch" {
+    task "periodic_batch" {
+      driver = "docker"
+      config {
+        image = "cogniteev/echo"
+      }
+      resources {
+        cpu    = 100
+        memory = 128
+        network {
+          mbits = 1
+        }
+      }
+    }
+  }
+}

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -13,6 +13,10 @@ type Config struct {
 	// until attempting to perfrom autopromote.
 	Canary int
 
+	// ForceBatch is a boolean flag that can be used to force a run of a periodic
+	// job upon registration.
+	ForceBatch bool
+
 	// ForceCount is a boolean flag that can be used to ignore running job counts
 	// and force the count based on the rendered job file.
 	ForceCount bool


### PR DESCRIPTION
A new 'force-batch' boolean flag has been added to the deploy
command which allows the immediate trigger of a periodic batch job
rather than waiting for the scheduled run. This is helpful when
deploying new code as operators can see the results quickly rather
than having to wait.

Closes #107