### PR TITLE
Add misspell to Makefile and run on travis runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 install:
 - go get github.com/golang/lint/golint
 - go get github.com/mitchellh/gox
+- go get github.com/client9/misspell/cmd/misspell
 script:
 - make test
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ PREFIX?=$(shell pwd)
 SRCFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 BUILDTAGS=
 
-.PHONY: clean all fmt vet lint build test install static
+.PHONY: clean all fmt vet lint spelling build test install static
 .DEFAULT: default
 
-all: clean build fmt lint test vet install
+all: clean build fmt lint spelling test vet install
 
 build:
 	@echo "==> Running $@..."
@@ -26,7 +26,7 @@ lint:
 	@echo "==> Running $@..."
 	@golint ./... | grep -v vendor | tee /dev/stderr
 
-test: fmt lint vet
+test: fmt lint vet spelling
 	@echo "==> Running $@..."
 	@go test -cover -v -tags "$(BUILDTAGS) cgo" $(shell go list ./... | grep -v vendor)
 
@@ -54,3 +54,12 @@ install:
 release:
 	@echo "==> Running $@..."
 	./scripts/build.sh
+
+spelling:
+	@echo "==> Running $@..."
+	@echo $(SRCFILES) |xargs misspell -error ;\
+	if [ $$? -ne 0 ]; then \
+	echo ""; \
+	echo "Misspell found spelling mistakes please fix them before submitting the"; \
+	echo "code for reviewal."; \
+	exit 1; fi

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -114,7 +114,7 @@ func (l *levantDeployment) deploy() (success bool) {
 
 	// Periodic and parameterized jobs do not return an evaluation and therefore
 	// can't perform the evaluationInspector unless we are forcing an instance of
-	// periodic which will yeild an EvalID.
+	// periodic which will yield an EvalID.
 	if !l.config.Job.IsPeriodic() && !l.config.Job.IsParameterized() ||
 		l.config.Job.IsPeriodic() && l.config.ForceBatch {
 

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -6,7 +6,7 @@ import (
 	"github.com/jrasell/levant/logging"
 )
 
-// initialTaskHealth is the Levant health status assosiated to a Task when it is
+// initialTaskHealth is the Levant health status associated to a Task when it is
 // initially discovered as part of the deployment.
 const initialTaskHealth = "unknown"
 


### PR DESCRIPTION
This change adds misspell which performs spell checking across the
codebase. Spell checking will be triggered on travis runs and will
now fail the test if mistakes are made.