### PR TITLE
Working curl command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Levant is an open source templating and deployment tool for [HashiCorp Nomad](ht
 
 ## Download
 
-* The Levant binary can be downloaded from the [GitHub releases page](https://github.com/jrasell/levant/releases) using `curl https://github.com/jrasell/levant/releases/download/v0.0.4/linux-amd64-levant -o levant`
+* The Levant binary can be downloaded from the [GitHub releases page](https://github.com/jrasell/levant/releases) using `curl -L https://github.com/jrasell/levant/releases/download/0.0.4/linux-amd64-levant -o levant`
 
 * A docker image can be found on [Docker Hub](hub.docker.com/jrasell/levant), the latest version can be downloaded using `docker pull jrasell/levant`.
 


### PR DESCRIPTION
The curl command in the README should follow redirects, and the tagged release is named `0.0.4` (without the v).