### PR TITLE
Fix issue where allocationStatusChecker logged incorrectly.

### DIFF
--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -187,14 +187,14 @@ func allocationStatusChecker(levantTasks map[string]map[string]string, allocs []
 				delete(levantTasks[alloc.ID], taskName)
 
 			case nomadStructs.TaskStatePending:
-				logging.Debug("levant/job_status_checker: task %s in allocation %s now in running state",
-					taskName, alloc.ID)
+				logging.Debug("levant/job_status_checker: task %s in allocation %s now in %s state",
+					taskName, alloc.ID, nomadStructs.TaskStatePending)
 
 			// If the task is dead, incrament the deadTask counter and remove the task
 			// from tracking.
 			case nomadStructs.TaskStateDead:
-				logging.Error("levant/job_status_checker: task %s in allocation %s now in dead state",
-					taskName, alloc.ID)
+				logging.Error("levant/job_status_checker: task %s in allocation %s now in %s state",
+					taskName, alloc.ID, nomadStructs.TaskStateDead)
 				*deadTask++
 				delete(levantTasks[alloc.ID], taskName)
 			}


### PR DESCRIPTION
Fixes an issue where the allocationStatusChecker function logged
that the task was running, where the case was for the pending
state. It updates the log message to use the Nomad struct value.

Closes #130