### PR TITLE
Add a catchall for unhandled failure cases

### DIFF
--- a/levant/failure_inspector.go
+++ b/levant/failure_inspector.go
@@ -135,6 +135,11 @@ func (l *levantDeployment) allocInspector(allocID string, wg *sync.WaitGroup) {
 			if desc != "" {
 				logging.Error("levant/failure_inspector: alloc %s incurred event %s because %s",
 					allocID, strings.ToLower(event.Type), strings.TrimSpace(desc))
+			} else {
+				logging.Error("levant/failure_inspector: alloc %s logged for failure; event_type: %s; message: %s",
+					allocID,
+					strings.ToLower(event.Type),
+					strings.ToLower(event.DisplayMessage))
 			}
 		}
 	}


### PR DESCRIPTION
This adds a catchall to log very useful events that are not displayed anywhere else upon deployment failure.

For example:
This output isn't very helpful to developers in deploy output. There's no explanation on _why_ it failed.
```
2018/04/17 12:40:59 PDT [ERROR] levant/deploy: deployment ee8fb7f8-4277-11e8-a099-17687cc3cd50 has status failed
2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 incurred event killed because the task was successfully killed
```

This change would add the missed events that were not picked up by the case statement.
```
  2018/04/17 12:40:59 PDT [ERROR] levant/deploy: deployment ee8fb7f8-4277-11e8-a099-17687cc3cd50 has status failed
+ 2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 logged for failure; event_type: received; message: task received by client
+ 2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 logged for failure; event_type: task setup; message: building task directory
+ 2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 logged for failure; event_type: template; message: missing: vault.read(secret/mysecret/key)
+ 2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 logged for failure; event_type: alloc unhealthy; message: task not running by deadline
  2018/04/17 12:40:59 PDT [ERROR] levant/failure_inspector: alloc fee09c3a-4277-11e8-b4ac-4fe73209d2f7 incurred event killed because the task was successfully killed
```
