### PR TITLE
Add Dockerfile.build to allow building during development.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-LABEL maintainer James Rasell<(jamesrasell@gmail.com> (@jrasell)
+LABEL maintainer James Rasell<(jamesrasell@gmail.com)> (@jrasell)
 LABEL vendor "jrasell"
 
 ENV LEVANT_VERSION 0.1.1

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,34 @@
+FROM golang:alpine AS builder
+
+RUN buildDeps=' \
+                make \
+                git \
+        ' \
+        set -x \
+        && apk --no-cache add $buildDeps \
+        && mkdir -p /go/src/github.com/jrasell/levant
+
+WORKDIR /go/src/github.com/jrasell/levant
+
+COPY . /go/src/github.com/jrasell/levant
+
+RUN \
+        make tools && \
+        make build
+
+FROM alpine:latest AS app
+
+LABEL maintainer James Rasell<(jamesrasell@gmail.com)> (@jrasell)
+LABEL vendor "jrasell"
+
+WORKDIR /usr/bin/
+
+COPY --from=builder /go/src/github.com/jrasell/levant/levant-local /usr/bin/levant
+
+RUN \
+        apk --no-cache add \
+        ca-certificates \
+        && chmod +x /usr/bin/levant \
+        && echo "Build complete."
+
+CMD ["levant", "--help"]


### PR DESCRIPTION
Recently the Dockerfile used to build the image which goes to hub
was updated to pull artefacts from GitHub releases which meant
you could no longer build images on the fly for testing. This adds
a build Dockerfile so that local changes can be built and tested.

Closes #167