### PR TITLE
Fix formatting issue with version summary output.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     # - Version (Tag with the `v` prefix stripped)
     # The default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}`
     # Date format is `2006-01-02_15:04:05`
-    ldflags: -s -w -X main.Version={{.Version}} -X main.GitCommit={{.Commit}} -X main.BuildDate={{.Date}} -X main.GitBranch={{.Tag}} -X main.GitState={{.Tag}} -X main.GitSummary={{.Commit}}"
+    ldflags: -s -w -X main.Version={{.Version}} -X main.GitCommit={{.Commit}} -X main.BuildDate={{.Date}} -X main.GitBranch={{.Tag}} -X main.GitState={{.Tag}} -X main.GitSummary={{.Commit}}
 
 archive:
   # You can change the name of the archive.


### PR DESCRIPTION
The Levant version summary output had an erronous trailing quote
which has been resolved by correcting the goreleaser file.

Closes #166