### PR TITLE
Addition of template functions allow Consul and Time lookups.

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	consul "github.com/hashicorp/consul/api"
+)
+
+// NewConsulClient is used to create a new client to interact with Consul.
+func NewConsulClient(addr string) (*consul.Client, error) {
+	config := consul.DefaultConfig()
+
+	if addr != "" {
+		config.Address = addr
+	}
+
+	c, err := consul.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -40,6 +40,10 @@ General Options:
   -canary-auto-promote=<seconds>
     The time in seconds, after which Levant will auto-promote a canary job
     if all canaries within the deployment are healthy.
+		
+  -consul-address=<addr>
+    The Consul host and port to use when making Consul KeyValue lookups for
+    template rendering.
 
   -force-batch
     Forces a new instance of the periodic job. A new instance will be created
@@ -73,6 +77,7 @@ func (c *DeployCommand) Synopsis() string {
 func (c *DeployCommand) Run(args []string) int {
 
 	var err error
+	var addr string
 	config := &structs.Config{}
 
 	flags := c.Meta.FlagSet("deploy", FlagSetVars)
@@ -80,6 +85,7 @@ func (c *DeployCommand) Run(args []string) int {
 
 	flags.StringVar(&config.Addr, "address", "", "")
 	flags.IntVar(&config.Canary, "canary-auto-promote", 0, "")
+	flags.StringVar(&addr, "consul-address", "", "")
 	flags.BoolVar(&config.ForceBatch, "force-batch", false, "")
 	flags.BoolVar(&config.ForceCount, "force-count", false, "")
 	flags.StringVar(&config.LogLevel, "log-level", "INFO", "")
@@ -110,7 +116,7 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	config.Job, err = template.RenderJob(config.TemplateFile, config.VaiableFile, &c.Meta.flagVars)
+	config.Job, err = template.RenderJob(config.TemplateFile, config.VaiableFile, addr, &c.Meta.flagVars)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
 		return 1

--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -30,7 +30,7 @@ func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		job, err := template.RenderJob(c.File, "", &fVars)
+		job, err := template.RenderJob(c.File, "", "", &fVars)
 		if err != nil {
 			t.Fatalf("case %d failed: %v", i, err)
 		}
@@ -61,7 +61,7 @@ func TestDeploy_checkForceBatch(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		job, err := template.RenderJob(c.File, "", &fVars)
+		job, err := template.RenderJob(c.File, "", "", &fVars)
 		if err != nil {
 			t.Fatalf("case %d failed: %v", i, err)
 		}

--- a/command/render.go
+++ b/command/render.go
@@ -29,6 +29,10 @@ Arguments:
     If no argument is given we look for a single *.nomad file
 
 General Options:
+
+  -consul-address=<addr>
+    The Consul host and port to use when making Consul KeyValue lookups for
+    template rendering.
 	
   -out=<file>
     Specify the path to write the rendered template out to, if a file exists at
@@ -49,13 +53,14 @@ func (c *RenderCommand) Synopsis() string {
 // Run triggers a run of the Levant template functions.
 func (c *RenderCommand) Run(args []string) int {
 
-	var variables, outPath, templateFile string
+	var addr, variables, outPath, templateFile string
 	var err error
 	var tpl *bytes.Buffer
 
 	flags := c.Meta.FlagSet("render", FlagSetVars)
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 
+	flags.StringVar(&addr, "consul-address", "", "")
 	flags.StringVar(&variables, "var-file", "", "")
 	flags.StringVar(&outPath, "out", "", "")
 
@@ -78,7 +83,7 @@ func (c *RenderCommand) Run(args []string) int {
 		return 1
 	}
 
-	tpl, err = template.RenderTemplate(templateFile, variables, &c.Meta.flagVars)
+	tpl, err = template.RenderTemplate(templateFile, variables, addr, &c.Meta.flagVars)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
 		return 1

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1,0 +1,119 @@
+package template
+
+import (
+	"errors"
+	"text/template"
+	"time"
+
+	consul "github.com/hashicorp/consul/api"
+	"github.com/rs/zerolog/log"
+)
+
+// funcMap builds the template functions and passes the consulClient where this
+// is required.
+func funcMap(consulClient *consul.Client) template.FuncMap {
+	return template.FuncMap{
+		"consulKey":          consulKeyFunc(consulClient),
+		"consulKeyExists":    consulKeyExistsFunc(consulClient),
+		"consulKeyOrDefault": consulKeyOrDefaultFunc(consulClient),
+		"timeNow":            timeNowFunc,
+		"timeNowUTC":         timeNowUTCFunc,
+		"timeNowTimezone":    timeNowTimezoneFunc(),
+	}
+}
+
+func consulKeyFunc(consulClient *consul.Client) func(string) (string, error) {
+	return func(s string) (string, error) {
+
+		if len(s) == 0 {
+			return "", nil
+		}
+
+		kv, _, err := consulClient.KV().Get(s, nil)
+		if err != nil {
+			return "", err
+		}
+
+		if kv == nil {
+			return "", errors.New("Consul KV not found")
+		}
+
+		v := string(kv.Value[:])
+		log.Info().Msgf("template/funcs: using Consul KV variable with key %s and value %s",
+			s, v)
+
+		return v, nil
+	}
+}
+
+func consulKeyExistsFunc(consulClient *consul.Client) func(string) (bool, error) {
+	return func(s string) (bool, error) {
+
+		if len(s) == 0 {
+			return false, nil
+		}
+
+		kv, _, err := consulClient.KV().Get(s, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if kv == nil {
+			return false, nil
+		}
+
+		log.Info().Msgf("template/funcs: found Consul KV variable with key %s", s)
+
+		return true, nil
+	}
+}
+
+func consulKeyOrDefaultFunc(consulClient *consul.Client) func(string, string) (string, error) {
+	return func(s, d string) (string, error) {
+
+		if len(s) == 0 {
+			log.Info().Msgf("template/funcs: using default Consul KV variable with value %s", d)
+			return d, nil
+		}
+
+		kv, _, err := consulClient.KV().Get(s, nil)
+		if err != nil {
+			return "", err
+		}
+
+		if kv == nil {
+			log.Info().Msgf("template/funcs: using default Consul KV variable with value %s", d)
+			return d, nil
+		}
+
+		v := string(kv.Value[:])
+		log.Info().Msgf("template/funcs: using Consul KV variable with key %s and value %s",
+			s, v)
+
+		return v, nil
+	}
+}
+
+func timeNowFunc() string {
+	return time.Now().Format("2006-01-02T15:04:05Z07:00")
+}
+
+func timeNowUTCFunc() string {
+	return time.Now().UTC().Format("2006-01-02T15:04:05Z07:00")
+}
+
+func timeNowTimezoneFunc() func(string) (string, error) {
+	return func(t string) (string, error) {
+
+		if t == "" {
+			return "", nil
+		}
+
+		loc, err := time.LoadLocation(t)
+		if err != nil {
+			return "", err
+		}
+
+		return time.Now().In(loc).Format("2006-01-02T15:04:05Z07:00"), nil
+	}
+}

--- a/template/render.go
+++ b/template/render.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"path"
 
+	"github.com/jrasell/levant/client"
 	"github.com/jrasell/levant/helper"
 	"github.com/rs/zerolog/log"
 	yaml "gopkg.in/yaml.v2"
@@ -17,9 +18,9 @@ import (
 
 // RenderJob takes in a template and variables performing a render of the
 // template followed by Nomad jobspec parse.
-func RenderJob(templateFile, variableFile string, flagVars *map[string]string) (job *nomad.Job, err error) {
+func RenderJob(templateFile, variableFile, addr string, flagVars *map[string]string) (job *nomad.Job, err error) {
 	var tpl *bytes.Buffer
-	tpl, err = RenderTemplate(templateFile, variableFile, flagVars)
+	tpl, err = RenderTemplate(templateFile, variableFile, addr, flagVars)
 	if err != nil {
 		return
 	}
@@ -30,44 +31,57 @@ func RenderJob(templateFile, variableFile string, flagVars *map[string]string) (
 
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
-func RenderTemplate(templateFile, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func RenderTemplate(templateFile, variableFile, addr string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+
+	t := &tmpl{}
+	t.flagVariables = flagVars
+	t.jobTemplateFile = templateFile
+	t.variableFile = variableFile
+
+	c, err := client.NewConsulClient(addr)
+	if err != nil {
+		return
+	}
+
+	t.consulClient = c
+
 	if variableFile == "" {
 		log.Debug().Msgf("template/render: no variable file passed, trying defaults")
-		if variableFile = helper.GetDefaultVarFile(); variableFile != "" {
-			log.Debug().Msgf("template/render: found default variable file, using %s", variableFile)
+		if t.variableFile = helper.GetDefaultVarFile(); t.variableFile != "" {
+			log.Debug().Msgf("template/render: found default variable file, using %s", t.variableFile)
 		}
 	}
 
 	// Process the variable file extension and log DEBUG so the template can be
 	// correctly rendered.
 	var ext string
-	if ext = path.Ext(variableFile); ext != "" {
+	if ext = path.Ext(t.variableFile); ext != "" {
 		log.Debug().Msgf("template/render: variable file extension %s detected", ext)
 	}
 
-	src, err := ioutil.ReadFile(templateFile)
+	src, err := ioutil.ReadFile(t.jobTemplateFile)
 	if err != nil {
 		return
 	}
 
 	// If no command line variables are passed; log this as DEBUG to provide much
 	// greater feedback.
-	if len(*flagVars) == 0 {
+	if len(*t.flagVariables) == 0 {
 		log.Debug().Msgf("template/render: no command line variables passed")
 	}
 
 	switch ext {
 	case terraformVarExtension:
-		tpl, err = renderTFTemplte(string(src), variableFile, flagVars)
+		tpl, err = t.renderTF(string(src))
 
 	case yamlVarExtension, ymlVarExtension:
 		// Run the render using a YAML variable file.
-		tpl, err = renderYAMLVarsTemplate(string(src), variableFile, flagVars)
+		tpl, err = t.renderYAMLVars(string(src))
 
 	case "":
 		// No variables file passed; render using any passed CLI variables.
 		log.Debug().Msgf("template/render: variable file not passed")
-		tpl, err = readJobFile(string(src), flagVars)
+		tpl, err = t.readJobFile(string(src))
 
 	default:
 		err = fmt.Errorf("variables file extension %v not supported", ext)
@@ -76,7 +90,7 @@ func RenderTemplate(templateFile, variableFile string, flagVars *map[string]stri
 	return
 }
 
-func renderTFTemplte(src, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func (t *tmpl) renderTF(src string) (tpl *bytes.Buffer, err error) {
 
 	c := &config.Config{}
 
@@ -85,7 +99,7 @@ func renderTFTemplte(src, variableFile string, flagVars *map[string]string) (tpl
 	tpl = &bytes.Buffer{}
 
 	// Load the variables file
-	if c, err = config.LoadFile(variableFile); err != nil {
+	if c, err = config.LoadFile(t.variableFile); err != nil {
 		return
 	}
 
@@ -96,28 +110,28 @@ func renderTFTemplte(src, variableFile string, flagVars *map[string]string) (tpl
 
 	// Merge variables passed on the CLI with those passed through a variables
 	// file.
-	mergedVars := helper.VariableMerge(&variables, flagVars)
+	mergedVars := helper.VariableMerge(&variables, t.flagVariables)
 
 	// Setup the template file for rendering
-	t := newTemplate()
+	tmpl := t.newTemplate()
 
-	if t, err = t.Parse(src); err != nil {
+	if tmpl, err = tmpl.Parse(src); err != nil {
 		return
 	}
 
-	if err = t.Execute(tpl, mergedVars); err != nil {
+	if err = tmpl.Execute(tpl, mergedVars); err != nil {
 		return
 	}
 	return tpl, nil
 }
 
-func renderYAMLVarsTemplate(src, variableFile string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func (t *tmpl) renderYAMLVars(src string) (tpl *bytes.Buffer, err error) {
 
 	// Setup our variables map and template
 	variables := make(map[string]interface{})
 	tpl = &bytes.Buffer{}
 
-	yamlFile, err := ioutil.ReadFile(variableFile)
+	yamlFile, err := ioutil.ReadFile(t.variableFile)
 	if err != nil {
 		return
 	}
@@ -128,32 +142,32 @@ func renderYAMLVarsTemplate(src, variableFile string, flagVars *map[string]strin
 
 	// Merge variables passed on the CLI with those passed through a variables
 	// file.
-	mergedVars := helper.VariableMerge(&variables, flagVars)
+	mergedVars := helper.VariableMerge(&variables, t.flagVariables)
 
 	// Setup the template file for rendering
-	t := newTemplate()
-	if t, err = t.Parse(string(src)); err != nil {
+	tmpl := t.newTemplate()
+	if tmpl, err = tmpl.Parse(string(src)); err != nil {
 		return
 	}
 
-	if err = t.Execute(tpl, mergedVars); err != nil {
+	if err = tmpl.Execute(tpl, mergedVars); err != nil {
 		return
 	}
 
 	return tpl, nil
 }
 
-func readJobFile(src string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func (t *tmpl) readJobFile(src string) (tpl *bytes.Buffer, err error) {
 
 	tpl = &bytes.Buffer{}
 
 	// Setup the template file for rendering
-	t := newTemplate()
-	if t, err = t.Parse(src); err != nil {
+	tmpl := t.newTemplate()
+	if tmpl, err = tmpl.Parse(src); err != nil {
 		return
 	}
 
-	if err = t.Execute(tpl, flagVars); err != nil {
+	if err = tmpl.Execute(tpl, t.flagVariables); err != nil {
 		return
 	}
 

--- a/template/render_test.go
+++ b/template/render_test.go
@@ -21,7 +21,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	fVars := make(map[string]string)
 
 	// Test basic TF template render.
-	job, err = RenderJob("test-fixtures/single_templated.nomad", "test-fixtures/test.tf", &fVars)
+	job, err = RenderJob("test-fixtures/single_templated.nomad", "test-fixtures/test.tf", "", &fVars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	}
 
 	// Test basic YAML template render.
-	job, err = RenderJob("test-fixtures/single_templated.nomad", "test-fixtures/test.yaml", &fVars)
+	job, err = RenderJob("test-fixtures/single_templated.nomad", "test-fixtures/test.yaml", "", &fVars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	}
 
 	// Test empty var-args and empty variable file render.
-	job, err = RenderJob("test-fixtures/none_templated.nomad", "", &fVars)
+	job, err = RenderJob("test-fixtures/none_templated.nomad", "", "", &fVars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 
 	// Test var-args only render.
 	fVars["job_name"] = testJobName
-	job, err = RenderJob("test-fixtures/single_templated.nomad", "", &fVars)
+	job, err = RenderJob("test-fixtures/single_templated.nomad", "", "", &fVars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	// Test var-args and variables file render.
 	delete(fVars, "job_name")
 	fVars["datacentre"] = testDCName
-	job, err = RenderJob("test-fixtures/multi_templated.nomad", "test-fixtures/test.yaml", &fVars)
+	job, err = RenderJob("test-fixtures/multi_templated.nomad", "test-fixtures/test.yaml", "", &fVars)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 
 	// Test var-args only render.
 	fVars["job_name"] = testJobName
-	_, err = RenderTemplate("test-fixtures/missing_var.nomad", "", &fVars)
+	_, err = RenderTemplate("test-fixtures/missing_var.nomad", "", "", &fVars)
 	if err == nil {
 		t.Fatal("expected err to not be nil")
 	}

--- a/template/template.go
+++ b/template/template.go
@@ -2,15 +2,32 @@ package template
 
 import (
 	"text/template"
+
+	consul "github.com/hashicorp/consul/api"
 )
+
+// tmpl provides everything needed to fully render and job template using
+// inbuilt functions.
+type tmpl struct {
+	consulClient    *consul.Client
+	flagVariables   *map[string]string
+	jobTemplateFile string
+	variableFile    string
+}
 
 const (
 	terraformVarExtension = ".tf"
 	yamlVarExtension      = ".yaml"
 	ymlVarExtension       = ".yml"
+	rightDelim            = "]]"
+	leftDelim             = "[["
 )
 
 // newTemplate returns an empty template with default options set
-func newTemplate() *template.Template {
-	return template.New("jobTemplate").Delims("[[", "]]").Option("missingkey=error")
+func (t *tmpl) newTemplate() *template.Template {
+	tmpl := template.New("jobTemplate")
+	tmpl.Delims(leftDelim, rightDelim)
+	tmpl.Option("missingkey=error")
+	tmpl.Funcs(funcMap(t.consulClient))
+	return tmpl
 }


### PR DESCRIPTION
This commit introduces template functions which allow lookups
against Consul as well as generic time lookups which are run over
the template during execution. A consul client has been added with
config flag in both the render and deploy commands as these may
need to connect to Consul for variable lookups.

Closes #58