### PR TITLE
#182 Exit after auto revert

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -45,6 +45,12 @@ General Options:
     The Consul host and port to use when making Consul KeyValue lookups for
     template rendering.
 
+  -exit-after-auto-revert
+    Determine whether Levant will exit (with non-zero exit code) after a 
+    deployment auto-reverts to the previous stable job. This flag is useful
+    if you want to be notified in case auto-revert happens (e.g. to fail your
+    CD pipeline).
+
   -force-batch
     Forces a new instance of the periodic job. A new instance will be created
     even if it violates the job's prohibit_overlap settings.
@@ -86,6 +92,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.StringVar(&config.Addr, "address", "", "")
 	flags.IntVar(&config.Canary, "canary-auto-promote", 0, "")
 	flags.StringVar(&addr, "consul-address", "", "")
+	flags.BoolVar(&config.ExitAfterAutoRevert, "exit-after-auto-revert", false, "")
 	flags.BoolVar(&config.ForceBatch, "force-batch", false, "")
 	flags.BoolVar(&config.ForceCount, "force-count", false, "")
 	flags.StringVar(&config.LogLevel, "log-level", "INFO", "")

--- a/levant/auto_revert.go
+++ b/levant/auto_revert.go
@@ -39,7 +39,7 @@ func (l *levantDeployment) autoRevert(jobID, depID *string) {
 		if success {
 			log.Info().Msgf("levant/auto_revert: auto-revert of job %s was successful", *jobID)
 			if l.config.ExitAfterAutoRevert {
-				os.Exit(1)
+				os.Exit(2)
 			}
 			break
 		} else {
@@ -57,7 +57,7 @@ func (l *levantDeployment) autoRevert(jobID, depID *string) {
 	if i == 5 {
 		log.Error().Msgf("levant/auto_revert: unable to check auto-revert of job %s", *jobID)
 		if l.config.ExitAfterAutoRevert {
-			os.Exit(2)
+			os.Exit(1)
 		}
 	}
 }

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	// until attempting to perfrom autopromote.
 	Canary int
 
+	// ExitAfterAutoRevert is a boolean flag that determine whether Levant will exit (with non-zero exit code)
+	// after a deployment auto-reverts to the previous stable job. This flag is useful if you want to be notified
+	// in case auto-revert happens (e.g. to fail your CD pipeline).
+	ExitAfterAutoRevert bool
+
 	// ForceBatch is a boolean flag that can be used to force a run of a periodic
 	// job upon registration.
 	ForceBatch bool


### PR DESCRIPTION
Fixes #182. Introduce `exit-after-auto-revert` flag which determines whether Levant will exit (with non-zero exit code) after a deployment auto-reverts to the previous stable job. This flag is useful if you want to be notified in case auto-revert happens (e.g. to fail your CD pipeline).