### PR TITLE
Added -allow-stale option into deploy

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -68,6 +68,9 @@ General Options:
   -var-file=<file>
     Used in conjunction with the -job-file will deploy a templated job to your
     Nomad cluster. [default: levant.(yaml|yml|tf)]
+
+  -allow-stale
+    Allow stale consistency mode for requests into nomad.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -95,6 +98,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.StringVar(&config.LogLevel, "log-level", "INFO", "")
 	flags.StringVar(&config.LogFormat, "log-format", "HUMAN", "")
 	flags.StringVar(&config.VaiableFile, "var-file", "", "")
+	flags.BoolVar(&config.AllowStale, "allow-stale", false, "")
 
 	if err = flags.Parse(args); err != nil {
 		return 1

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -98,7 +98,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 
 	flags.StringVar(&config.Addr, "address", "", "")
-	flags.BoolVar(&config.AllowStale, "allow-stale", false, "")d
+	flags.BoolVar(&config.AllowStale, "allow-stale", false, "")
 	flags.IntVar(&config.Canary, "canary-auto-promote", 0, "")
 	flags.StringVar(&addr, "consul-address", "", "")
 	flags.BoolVar(&config.ForceBatch, "force-batch", false, "")

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -98,6 +98,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 
 	flags.StringVar(&config.Addr, "address", "", "")
+	flags.BoolVar(&config.AllowStale, "allow-stale", false, "")d
 	flags.IntVar(&config.Canary, "canary-auto-promote", 0, "")
 	flags.StringVar(&addr, "consul-address", "", "")
 	flags.BoolVar(&config.ForceBatch, "force-batch", false, "")
@@ -105,12 +106,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.BoolVar(&config.IgnoreNoChanges, "ignore-no-changes", false, "")
 	flags.StringVar(&config.LogLevel, "log-level", "INFO", "")
 	flags.StringVar(&config.LogFormat, "log-format", "HUMAN", "")
-<<<<<<< HEAD
-	flags.StringVar(&config.VaiableFile, "var-file", "", "")
-	flags.BoolVar(&config.AllowStale, "allow-stale", false, "")
-=======
 	flags.Var((*helper.FlagStringSlice)(&config.VariableFiles), "var-file", "")
->>>>>>> b4741ff0afd8ccfaef7c23a1676e455eceeb77cb
 
 	if err = flags.Parse(args); err != nil {
 		return 1

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -267,7 +267,7 @@ func (l *levantDeployment) deploymentWatcher(depID string) (success bool) {
 		go l.canaryAutoPromote(depID, l.config.Canary, canaryChan, deploymentChan)
 	}
 
-	q := &nomad.QueryOptions{WaitIndex: 1, AllowStale: true, WaitTime: wt}
+	q := &nomad.QueryOptions{WaitIndex: 1, AllowStale: l.config.AllowStale, WaitTime: wt}
 
 	for {
 
@@ -372,7 +372,7 @@ func (l *levantDeployment) checkCanaryDeploymentHealth(depID string) (healthy bo
 
 	var unhealthy int
 
-	dep, _, err := l.nomad.Deployments().Info(depID, &nomad.QueryOptions{AllowStale: true})
+	dep, _, err := l.nomad.Deployments().Info(depID, &nomad.QueryOptions{AllowStale: l.config.AllowStale})
 	if err != nil {
 		log.Error().Err(err).Msgf("levant/deploy: unable to query deployment %s for health: %v", depID)
 		return

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -43,4 +43,7 @@ type Config struct {
 	// VaiableFile contains the variables which will be substituted into the
 	// templateFile before deployment.
 	VaiableFile string
+
+	// AllowStale sets consistency level for nomad query - https://www.nomadproject.io/api/index.html#consistency-modes
+	AllowStale bool
 }


### PR DESCRIPTION
Hey! 
I tried adding an option allow-stale for deploy command for simple reasons: 
We have a pretty bad network between servers and sometimes, when we apply deploy, we get errors because nomad didn't have time to replicate the data about the deployment to neighboring servers.

Would be happy to receive your feedback!