### PR TITLE
Fix broken Docker Hub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Levant is an open source templating and deployment tool for [HashiCorp Nomad](ht
 
 * The Levant binary can be downloaded from the [GitHub releases page](https://github.com/jrasell/levant/releases) using `curl -L https://github.com/jrasell/levant/releases/download/0.1.0/linux-amd64-levant -o levant`
 
-* A docker image can be found on [Docker Hub](hub.docker.com/jrasell/levant), the latest version can be downloaded using `docker pull jrasell/levant`.
+* A docker image can be found on [Docker Hub](https://hub.docker.com/r/jrasell/levant/), the latest version can be downloaded using `docker pull jrasell/levant`.
 
 * Levant can be built from source by firstly cloning the repository `git clone github.com/jrasell/levant.git`. Once cloned the binary can be built using the `make` command or invoking the `build.sh` script located in the scripts directory.
 


### PR DESCRIPTION
Just a small typo fix in the README so the Docker Hub link works.