### PR TITLE
Add `-ignore-no-changes` flag to deploy CLI command

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -24,11 +24,11 @@ func (c *DeployCommand) Help() string {
 	helpText := `
 Usage: levant deploy [options] [TEMPLATE]
 
-	Deploy a Nomad job based on input templates and variable files. The deploy 
-	command supports passing variables individually on the command line. Multiple
-	commands can be passed in the format of -var 'key=value'. Variables passed 
-	via the command line take precedence over the same variable declared within 
-	a passed variable file.
+  Deploy a Nomad job based on input templates and variable files. The deploy
+  command supports passing variables individually on the command line. Multiple
+  commands can be passed in the format of -var 'key=value'. Variables passed
+  via the command line take precedence over the same variable declared within
+  a passed variable file.
 
 Arguments:
 
@@ -57,6 +57,12 @@ General Options:
     Use the taskgroup count from the Nomad jobfile instead of the count that
     is currently set in a running job.
 
+  -ignore-no-changes
+    By default if no changes are detected when running a deployment Levant will
+    exit with a status 1 to indicate a deployment didn't happen. This behaviour
+    can be changed using this flag so that Levant will exit cleanly ensuring CD
+    pipelines don't fail when no changes are detected.
+
   -log-level=<level>
     Specify the verbosity level of Levant's logs. Valid values include DEBUG,
     INFO, and WARN, in decreasing order of verbosity. The default is INFO.
@@ -68,7 +74,7 @@ General Options:
   -var-file=<file>
     Used in conjunction with the -job-file will deploy a templated job to your
     Nomad cluster. You can repeat this flag multiple times to supply multiple var-files.
-	[default: levant.(yaml|yml|tf)]
+    [default: levant.(yaml|yml|tf)]
 `
 	return strings.TrimSpace(helpText)
 }
@@ -93,6 +99,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.StringVar(&addr, "consul-address", "", "")
 	flags.BoolVar(&config.ForceBatch, "force-batch", false, "")
 	flags.BoolVar(&config.ForceCount, "force-count", false, "")
+	flags.BoolVar(&config.IgnoreNoChanges, "ignore-no-changes", false, "")
 	flags.StringVar(&config.LogLevel, "log-level", "INFO", "")
 	flags.StringVar(&config.LogFormat, "log-format", "HUMAN", "")
 	flags.Var((*helper.FlagStringSlice)(&config.VariableFiles), "var-file", "")

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -27,6 +27,10 @@ type Config struct {
 	// and force the count based on the rendered job file.
 	ForceCount bool
 
+	// IgnoreNoChanges is used to allow operators to force Levant to exit cleanly
+	// even if there are no changes found during the plan.
+	IgnoreNoChanges bool
+
 	// Job represents the Nomad Job definition that will be deployed.
 	Job *nomad.Job
 


### PR DESCRIPTION
Previously if no changes were detected on a deployment Levant
would exit with status 1 which caused some CI/CD pipeline issues.

This change allows users to change this behaviouer using the flag
whereby if no changes are detected, Levant will exit with a status
code 0.

Closes #186