### PR TITLE
Add additional template funcs to allow parsing of types.

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1,8 +1,10 @@
 package template
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"text/template"
 	"time"
 
@@ -18,6 +20,11 @@ func funcMap(consulClient *consul.Client) template.FuncMap {
 		"consulKeyExists":    consulKeyExistsFunc(consulClient),
 		"consulKeyOrDefault": consulKeyOrDefaultFunc(consulClient),
 		"loop":               loop,
+		"parseBool":          parseBool,
+		"parseFloat":         parseFloat,
+		"parseInt":           parseInt,
+		"parseJSON":          parseJSON,
+		"parseUint":          parseUint,
 		"timeNow":            timeNowFunc,
 		"timeNowUTC":         timeNowUTCFunc,
 		"timeNowTimezone":    timeNowTimezoneFunc(),
@@ -118,6 +125,66 @@ func loop(ints ...int64) (<-chan int64, error) {
 	}()
 
 	return ch, nil
+}
+
+func parseBool(s string) (bool, error) {
+	if s == "" {
+		return false, nil
+	}
+
+	result, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, err
+	}
+	return result, nil
+}
+
+func parseFloat(s string) (float64, error) {
+	if s == "" {
+		return 0.0, nil
+	}
+
+	result, err := strconv.ParseFloat(s, 10)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+func parseInt(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	result, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
+}
+
+func parseJSON(s string) (interface{}, error) {
+	if s == "" {
+		return map[string]interface{}{}, nil
+	}
+
+	var data interface{}
+	if err := json.Unmarshal([]byte(s), &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func parseUint(s string) (uint64, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	result, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return result, nil
 }
 
 func timeNowFunc() string {


### PR DESCRIPTION
Addition of parse* functions to help with programatic templating
of job files. The parseJSON is particulary helpful as variables
can be stored in Consul KV as a JSON block and then parsed and
used within the template job file.

Closes #209