### PR TITLE
Do not fail a deployment when nodes have been filtered during eval.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -254,8 +254,10 @@ func (l *levantDeployment) evaluationInspector(evalID *string) error {
 				}
 			}
 
-			return fmt.Errorf("evaluation %v finished with status %s but failed to place allocations",
-				*evalID, evalInfo.Status)
+			// Do not return an error here; there could well be information from
+			// Nomad detailing filtered nodes but the deployment will still be
+			// successful. GH-220.
+			return nil
 
 		default:
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
Previously if an eval included information about filtered nodes
the deployment would show as failed even if the non-filtered evals
placed successfully. This change means Levant will not fail when
evals are filtered and will continue to track the rest of the
deployment.

Closes #220