### PR TITLE
Add plan command to allow running a plan whilst using templating.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -36,6 +36,11 @@ func Commands(metaPtr *command.Meta) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"plan": func() (cli.Command, error) {
+			return &command.PlanCommand{
+				Meta: meta,
+			}, nil
+		},
 		"render": func() (cli.Command, error) {
 			return &command.RenderCommand{
 				Meta: meta,

--- a/levant/dispatch.go
+++ b/levant/dispatch.go
@@ -3,7 +3,6 @@ package levant
 import (
 	nomad "github.com/hashicorp/nomad/api"
 	"github.com/jrasell/levant/client"
-	"github.com/jrasell/levant/levant/structs"
 	"github.com/rs/zerolog/log"
 )
 
@@ -20,7 +19,6 @@ func TriggerDispatch(job string, metaMap map[string]string, payload []byte, addr
 	// TODO: Potential refactor so that dispatch does not need to use the
 	// levantDeployment object. Requires client refactor.
 	dep := &levantDeployment{}
-	dep.config = &structs.Config{}
 	dep.nomad = client
 
 	success := dep.dispatch(job, metaMap, payload)
@@ -55,9 +53,9 @@ func (l *levantDeployment) dispatch(job string, metaMap map[string]string, paylo
 
 	// In order to correctly run the jobStatusChecker we need to correctly
 	// assign the dispatched job ID/Name based on the invoked job.
-	l.config.Job = &nomad.Job{}
-	l.config.Job.ID = &eval.DispatchedJobID
-	l.config.Job.Name = &eval.DispatchedJobID
+	l.config.Template.Job = &nomad.Job{}
+	l.config.Template.Job.ID = &eval.DispatchedJobID
+	l.config.Template.Job.Name = &eval.DispatchedJobID
 
 	// Perform the evaluation inspection to ensure to check for any possible
 	// errors in triggering the dispatch job.

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -21,7 +21,7 @@ func (l *levantDeployment) jobStatusChecker(evalID *string) bool {
 
 	// Run the initial job status check to ensure the job reaches a state of
 	// running.
-	jStatus := l.simpleJobStatusChecker(*l.config.Job.ID)
+	jStatus := l.simpleJobStatusChecker(*l.config.Template.Job.ID)
 
 	// Periodic and parameterized batch jobs do not produce evaluations and so
 	// can only go through the simplest of checks.
@@ -46,7 +46,7 @@ func (l *levantDeployment) simpleJobStatusChecker(jobID string) bool {
 
 	for {
 
-		job, meta, err := l.nomad.Jobs().Info(*l.config.Job.Name, q)
+		job, meta, err := l.nomad.Jobs().Info(*l.config.Template.Job.Name, q)
 		if err != nil {
 			log.Error().Err(err).Msg("levant/job_status_checker: unable to query job information from Nomad")
 			return false

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -8,18 +8,11 @@ const (
 	JobIDContextField = "job_id"
 )
 
-// Config is the main struct used to configure and run a Levant deployment on
+// DeployConfig is the main struct used to configure and run a Levant deployment on
 // a given target job.
-type Config struct {
-	// Addr is the Nomad API address to use for all calls and must include both
-	// protocol and port.
-	Addr string
-
-	// AllowStale sets consistency level for nomad query - https://www.nomadproject.io/api/index.html#consistency-modes
-	AllowStale bool
-
+type DeployConfig struct {
 	// Canary enables canary autopromote and is the value in seconds to wait
-	// until attempting to perfrom autopromote.
+	// until attempting to perform autopromote.
 	Canary int
 
 	// ForceBatch is a boolean flag that can be used to force a run of a periodic
@@ -29,19 +22,36 @@ type Config struct {
 	// ForceCount is a boolean flag that can be used to ignore running job counts
 	// and force the count based on the rendered job file.
 	ForceCount bool
+}
 
+// ClientConfig is the config struct which houses all the information needed to connect
+// to the external services and endpoints.
+type ClientConfig struct {
+	// Addr is the Nomad API address to use for all calls and must include both
+	// protocol and port.
+	Addr string
+
+	// ConsulAddr is the Consul API address to use for all calls.
+	ConsulAddr string
+
+	// AllowStale sets consistency level for nomad query
+	// https://www.nomadproject.io/api/index.html#consistency-modes
+	AllowStale bool
+}
+
+// PlanConfig contains any configuration options that are specific to running a
+// Nomad plan.
+type PlanConfig struct {
 	// IgnoreNoChanges is used to allow operators to force Levant to exit cleanly
 	// even if there are no changes found during the plan.
 	IgnoreNoChanges bool
+}
 
+// TemplateConfig contains all the job templating configuration options including
+// the rendered job.
+type TemplateConfig struct {
 	// Job represents the Nomad Job definition that will be deployed.
 	Job *nomad.Job
-
-	// LogLevel is the level at which Levant will log.
-	LogLevel string
-
-	// LogFormat is the format Levant will use for logging.
-	LogFormat string
 
 	// TemplateFile is the job specification template which will be rendered
 	// before being deployed to the cluster.

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -31,9 +31,9 @@ func TriggerScalingEvent(config *structs.ScalingConfig) bool {
 
 	// Setup a deployment object, as a scaling event is a deployment and should
 	// go through the same process and code upgrades.
-	deploymentConfig := &structs.Config{}
-	deploymentConfig.Job = job
-	deploymentConfig.ForceCount = true
+	deploymentConfig := &levant.DeployConfig{}
+	deploymentConfig.Template.Job = job
+	deploymentConfig.Deploy.ForceCount = true
 
 	log.Info().Msg("levant/scale: job will now be deployed with updated counts")
 


### PR DESCRIPTION
When performing larger job changes; Nomad plan provides useful
insights into what changes will happen. Previously Levant would run
a plan during the deploy command run, but would move straight onto
the deploy part. The plan command addition means you can render a
templated job and see what changes will be made without triggering
a deployment.

Closes #229