### PR TITLE
Fix NPE - seems like a missing initialization

### DIFF
--- a/scale/scale.go
+++ b/scale/scale.go
@@ -32,8 +32,8 @@ func TriggerScalingEvent(config *structs.ScalingConfig) bool {
 	// Setup a deployment object, as a scaling event is a deployment and should
 	// go through the same process and code upgrades.
 	deploymentConfig := &levant.DeployConfig{}
-	deploymentConfig.Template.Job = job
-	deploymentConfig.Deploy.ForceCount = true
+	deploymentConfig.Template = &structs.TemplateConfig{Job: job}
+	deploymentConfig.Deploy = &structs.DeployConfig{ForceCount: true}
 
 	log.Info().Msg("levant/scale: job will now be deployed with updated counts")
 


### PR DESCRIPTION
@jrasell Hey, there was a simple NPE bug 😃  in the most recent release causing NPEs on scale outs

```
func Test_BadCode(t *testing.T) {
	job := &nomad.Job{}
	deploymentConfig := &levant.DeployConfig{}
	deploymentConfig.Template.Job = job
	deploymentConfig.Deploy.ForceCount = true
}

func Test_GoodCode(t *testing.T) {
	job := &nomad.Job{}
	deploymentConfig := &levant.DeployConfig{}
	deploymentConfig.Template = &structs.TemplateConfig{Job: job}
	deploymentConfig.Deploy = &structs.DeployConfig{ForceCount: true}
}
```

I think this change should be merged asap. Our deploys crashed in production with:

```
2018-10-05T14:11:59Z |INFO| levant/scale: task group api-nomad-prod-hostnet will scale-out from 300 to 350 job_id=api-nomad
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb72245]

goroutine 1 [running]:
github.com/jrasell/levant/scale.TriggerScalingEvent(0xc0001aeae0, 0x4)
    /home/travis/gopath/src/github.com/jrasell/levant/scale/scale.go:35 +0x455
github.com/jrasell/levant/command.(*ScaleOutCommand).Run(0xc0001b33c0, 0xc00001c070, 0x3, 0x3, 0xc0001b3100)
    /home/travis/gopath/src/github.com/jrasell/levant/command/scale_out.go:111 +0x407
github.com/jrasell/levant/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc0001eba40, 0xc0001eba40, 0x7, 0xc0001b3140)
    /home/travis/gopath/src/github.com/jrasell/levant/vendor/github.com/mitchellh/cli/cli.go:255 +0x207
main.RunCustom(0xc00001c060, 0x4, 0x4, 0xc0002a7bf0, 0x0)
    /home/travis/gopath/src/github.com/jrasell/levant/main.go:62 +0x33c
main.Run(0xc00001c060, 0x4, 0x4, 0xc000086058)
    /home/travis/gopath/src/github.com/jrasell/levant/main.go:30 +0x56
main.main()
    /home/travis/gopath/src/github.com/jrasell/levant/main.go:24 +0x15d
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```