### PR TITLE
Fix bug where job deploys with count 0 hang.

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -139,6 +139,10 @@ func (l *levantDeployment) deploy() (success bool) {
 		}
 	}
 
+	if l.isJobZeroCount() {
+		return true
+	}
+
 	switch *l.config.Template.Job.Type {
 	case nomadStructs.JobTypeService:
 
@@ -484,4 +488,13 @@ func (l *levantDeployment) dynamicGroupCountUpdater() error {
 		}
 	}
 	return nil
+}
+
+func (l *levantDeployment) isJobZeroCount() bool {
+	for _, tg := range l.config.Template.Job.TaskGroups {
+		if *tg.Count > 0 {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Jobs with count 0 do not produce deployments and therefore when
performing a deployment with a count of zero Levant would hang
attempting to track a deployment which would never occur. This
introduces a checker to see whether the job has any taskgroups
with a count greater than zero.

Closes #243