### PR TITLE
Fix panic in deployment due to unsafe count checking on taskgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.5 (25 October 2018)
+
+BUG FIXES:
+ * Fix panic in deployment where count is not specified due to unsafe count checking on task groups [GH-249](https://github.com/jrasell/levant/pull/249)
+
 ## 0.2.4 (24 October 2018)
 
 BUG FIXES:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 LABEL maintainer James Rasell<(jamesrasell@gmail.com)> (@jrasell)
 LABEL vendor "jrasell"
 
-ENV LEVANT_VERSION 0.2.4
+ENV LEVANT_VERSION 0.2.5
 
 WORKDIR /usr/bin/
 

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -492,7 +492,9 @@ func (l *levantDeployment) dynamicGroupCountUpdater() error {
 
 func (l *levantDeployment) isJobZeroCount() bool {
 	for _, tg := range l.config.Template.Job.TaskGroups {
-		if *tg.Count > 0 {
+		if tg.Count == nil {
+			return false
+		} else if *tg.Count > 0 {
 			return false
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@ package version
 import "fmt"
 
 // Version is the main version number that is being run at the moment.
-const Version = "0.2.4"
+const Version = "0.2.5"
 
 // VersionPrerelease is a pre-release marker for the version. If this is ""
 // (empty string) then it means that it is a final release. Otherwise, this is


### PR DESCRIPTION
When checking if a taskgroup count was greater than zero, it did
not account for the potential for it to be nil, when a count is
not specified and uses the default 1. This fixes that bug and
releases 0.2.5 as an emergency fix.

Closes #248