### PR TITLE
Fix miss behavior when flag 'ignore-no-changes' was set.

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -181,9 +181,11 @@ func (c *DeployCommand) Run(args []string) int {
 		Template: config.Template,
 	}
 
-	planSuccess := levant.TriggerPlan(&p)
+	planSuccess, changes := levant.TriggerPlan(&p)
 	if !planSuccess {
 		return 1
+	} else if !changes && p.Plan.IgnoreNoChanges {
+		return 0
 	}
 
 	success := levant.TriggerDeployment(config, nil)

--- a/command/plan.go
+++ b/command/plan.go
@@ -131,9 +131,11 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	success := levant.TriggerPlan(config)
+	success, changes := levant.TriggerPlan(config)
 	if !success {
 		return 1
+	} else if !changes && config.Plan.IgnoreNoChanges {
+		return 0
 	}
 
 	return 0


### PR DESCRIPTION
Based on documentation, this flag should not invoke deployment when job hasn't changes, only return '0' code rather then '1'.
