### PR TITLE
WIP: Update flagVars so -var can take in nested variables

### DIFF
--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 	depCommand := &DeployCommand{}
 	canaryPromote := 30
 
@@ -44,7 +44,7 @@ func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 
 func TestDeploy_checkForceBatch(t *testing.T) {
 
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 	depCommand := &DeployCommand{}
 	forceBatch := true
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -26,7 +26,7 @@ type Meta struct {
 	UI cli.Ui
 
 	// These are set by command-line flags
-	flagVars map[string]string
+	flagVars map[string]interface{}
 }
 
 // FlagSet returns a FlagSet with the common flags that every

--- a/helper/kvflag.go
+++ b/helper/kvflag.go
@@ -7,7 +7,7 @@ import (
 
 // Flag is a flag.Value implementation for parsing user variables
 // from the command-line in the format of '-var key=value'.
-type Flag map[string]string
+type Flag map[string]interface{}
 
 func (v *Flag) String() string {
 	return ""
@@ -22,7 +22,7 @@ func (v *Flag) Set(raw string) error {
 	}
 
 	if *v == nil {
-		*v = make(map[string]string)
+		*v = make(map[string]interface{})
 	}
 
 	key, value := raw[0:idx], raw[idx+1:]

--- a/helper/kvflag_test.go
+++ b/helper/kvflag_test.go
@@ -8,24 +8,24 @@ import (
 func TestHelper_Set(t *testing.T) {
 	cases := []struct {
 		Input  string
-		Output map[string]string
+		Output map[string]interface{}
 		Error  bool
 	}{
 		{
 			"key=value",
-			map[string]string{"key": "value"},
+			map[string]interface{}{"key": "value"},
 			false,
 		},
 
 		{
 			"key=",
-			map[string]string{"key": ""},
+			map[string]interface{}{"key": ""},
 			false,
 		},
 
 		{
 			"key=foo=bar",
-			map[string]string{"key": "foo=bar"},
+			map[string]interface{}{"key": "foo=bar"},
 			false,
 		},
 
@@ -43,7 +43,7 @@ func TestHelper_Set(t *testing.T) {
 			t.Fatalf("bad error. Input: %#v", tc.Input)
 		}
 
-		actual := map[string]string(*f)
+		actual := (map[string]interface{})(*f)
 		if !reflect.DeepEqual(actual, tc.Output) {
 			t.Fatalf("bad: %#v", actual)
 		}

--- a/helper/variable.go
+++ b/helper/variable.go
@@ -7,7 +7,7 @@ import (
 // VariableMerge merges the passed file variables with the flag variabes to
 // provide a single set of variables. The flagVars will always prevale over file
 // variables.
-func VariableMerge(fileVars *map[string]interface{}, flagVars *map[string]string) map[string]interface{} {
+func VariableMerge(fileVars *map[string]interface{}, flagVars *map[string]interface{}) map[string]interface{} {
 
 	out := make(map[string]interface{})
 

--- a/helper/variable.go
+++ b/helper/variable.go
@@ -1,30 +1,15 @@
 package helper
 
 import (
-	"github.com/rs/zerolog/log"
+	"github.com/imdario/mergo"
 )
 
 // VariableMerge merges the passed file variables with the flag variabes to
 // provide a single set of variables. The flagVars will always prevale over file
 // variables.
 func VariableMerge(fileVars *map[string]interface{}, flagVars *map[string]interface{}) map[string]interface{} {
-
-	out := make(map[string]interface{})
-
-	for k, v := range *flagVars {
-		log.Info().Msgf("helper/variable: using command line variable with key %s and value %s", k, v)
-		out[k] = v
+	if err := mergo.Merge(&*fileVars, *flagVars, mergo.WithOverride); err != nil {
+		panic(err)
 	}
-
-	for k, v := range *fileVars {
-		if _, ok := out[k]; ok {
-			log.Debug().Msgf("helper/variable: variable from file with key %s and value %s overridden by CLI var",
-				k, v)
-			continue
-		}
-		log.Info().Msgf("helper/variable: using variable with key %s and value %v from file", k, v)
-		out[k] = v
-	}
-
-	return out
+	return *fileVars
 }

--- a/helper/variable_test.go
+++ b/helper/variable_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestHelper_VariableMerge(t *testing.T) {
 
-	flagVars := make(map[string]string)
-	flagVars["job_name"] = "levantExample"
+	flagVars := make(map[string]interface{})
+	flagVars["job_name"] = "levantExample.nested.variable"
 	flagVars["datacentre"] = "dc13"
 
 	fileVars := make(map[string]interface{})
@@ -16,7 +16,7 @@ func TestHelper_VariableMerge(t *testing.T) {
 	fileVars["CPU_MHz"] = 500
 
 	expected := make(map[string]interface{})
-	expected["job_name"] = "levantExample"
+	expected["job_name"] = "levantExample.nested.variable"
 	expected["datacentre"] = "dc13"
 	expected["CPU_MHz"] = 500
 

--- a/template/render.go
+++ b/template/render.go
@@ -19,7 +19,7 @@ import (
 
 // RenderJob takes in a template and variables performing a render of the
 // template followed by Nomad jobspec parse.
-func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (job *nomad.Job, err error) {
+func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]interface{}) (job *nomad.Job, err error) {
 	var tpl *bytes.Buffer
 	tpl, err = RenderTemplate(templateFile, variableFiles, addr, flagVars)
 	if err != nil {

--- a/template/render.go
+++ b/template/render.go
@@ -32,7 +32,7 @@ func RenderJob(templateFile string, variableFiles []string, addr string, flagVar
 
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
-func RenderTemplate(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func RenderTemplate(templateFile string, variableFiles []string, addr string, flagVars *map[string]interface{}) (tpl *bytes.Buffer, err error) {
 
 	t := &tmpl{}
 	t.flagVariables = flagVars

--- a/template/render_test.go
+++ b/template/render_test.go
@@ -23,7 +23,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	var err error
 
 	// Start with an empty passed var args map.
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 
 	// Test basic TF template render.
 	job, err = RenderJob("test-fixtures/single_templated.nomad", []string{"test-fixtures/test.tf"}, "", &fVars)

--- a/template/template.go
+++ b/template/template.go
@@ -10,7 +10,7 @@ import (
 // inbuilt functions.
 type tmpl struct {
 	consulClient    *consul.Client
-	flagVariables   *map[string]string
+	flagVariables   *map[string]interface{}
 	jobTemplateFile string
 	variableFiles   []string
 }

--- a/template/test-fixtures/nested_templated.nomad
+++ b/template/test-fixtures/nested_templated.nomad
@@ -1,0 +1,51 @@
+job "[[.job_name]]" {
+  datacenters = ["[[.datacentre]]"]
+  type = "service"
+  update {
+    max_parallel     = 1
+    min_healthy_time = "10s"
+    healthy_deadline = "1m"
+    auto_revert      = true
+  }
+
+  group "[[env "GROUP_NAME_ENV"]]" {
+    count = "[[.service.count]]"
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay = "25s"
+      mode = "delay"
+    }
+    ephemeral_disk {
+      size = 300
+    }
+    task "redis" {
+      driver = "docker"
+      config {
+        image = "redis:3.2"
+        port_map {
+          db = 6379
+        }
+      }
+      resources {
+        cpu    = 500
+        memory = 256
+        network {
+          mbits = 10
+          port "db" {}
+        }
+      }
+      service {
+        name = "global-redis-check"
+        tags = ["global", "cache"]
+        port = "db"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/template/test-fixtures/test.yaml
+++ b/template/test-fixtures/test.yaml
@@ -1,1 +1,10 @@
-job_name: levantExample
+---
+  service:
+    name: service
+    count: 2
+  slack:
+    channel: alerts-app-dev
+  datacenter: dc1
+  region: global
+  network_namespace: app-dev
+  job_name: levantExample


### PR DESCRIPTION
Refactors the tmpl struct's flagVariables field from a *map[string]string to a  *map[string]interface{}. This allows nested variables to be passed into the tmpl struct without being cast to a string type.

I'm a bit unsure if there are any other code changes necessary in order to make this work besides updating the struct field. I did take a look around and know that we're already rendering nomad job files with variables like `[[.nginx_ingress.version]]`... so I figured what has been setup in this project via it's own template package, in addition to, the go text/template package already handles parsing nested variables. 

I am new to learning Go and this seemed like a good issue to jump in and get my hands dirty, however, if there is anything I can do to further improve the pr further, feel free to let me know.

This is meant to fixed the reported bug in #257.
