### PR TITLE
add exists template function

### DIFF
--- a/template/funcs.go
+++ b/template/funcs.go
@@ -23,6 +23,7 @@ func funcMap(consulClient *consul.Client) template.FuncMap {
 		"consulKeyExists":    consulKeyExistsFunc(consulClient),
 		"consulKeyOrDefault": consulKeyOrDefaultFunc(consulClient),
 		"env":                envFunc(),
+		"exists":             exists,
 		"fileContents":       fileContents(),
 		"loop":               loop,
 		"parseBool":          parseBool,
@@ -36,6 +37,16 @@ func funcMap(consulClient *consul.Client) template.FuncMap {
 		"toLower":            toLower,
 		"toUpper":            toUpper,
 	}
+}
+
+func exists(i interface{}, name string) (ok bool, err error) {
+	switch kv := i.(type) {
+	case map[string]interface{}:
+		_, ok = kv[name]
+	default:
+		err = errors.New("exists cannot be used on non-maps")
+	}
+	return
 }
 
 func consulKeyFunc(consulClient *consul.Client) func(string) (string, error) {


### PR DESCRIPTION
When using levant with a common template but different vars files, it would be useful to be able to test for the existence of a key in a map. This PR adds an `exists` template function to test for key existence without failing due to the template `missingkey` option being set.

Example usage:

```
job "foo" {
[[ if exists . "constraint" ]]
  constraint {
    attribute = "${[[ .constraint.attribute ]]}"
    value = "[[ .constraint.value ]]"
  }
[[- end ]]

  ...
}
``` 