### PR TITLE
Use missingkey=zero rather than error in template rendering.

### DIFF
--- a/template/render_test.go
+++ b/template/render_test.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	nomad "github.com/hashicorp/nomad/api"
@@ -107,15 +106,5 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	}
 	if *job.TaskGroups[0].Name != testEnvValue {
 		t.Fatalf("expected %s but got %v", testEnvValue, *job.TaskGroups[0].Name)
-	}
-
-	// Test var-args only render.
-	fVars["job_name"] = testJobName
-	_, err = RenderTemplate("test-fixtures/missing_var.nomad", []string{}, "", &fVars)
-	if err == nil {
-		t.Fatal("expected err to not be nil")
-	}
-	if !strings.Contains(err.Error(), "binary_url") {
-		t.Fatal("expected err to mention missing var (binary_url)")
 	}
 }

--- a/template/template.go
+++ b/template/template.go
@@ -28,7 +28,7 @@ const (
 func (t *tmpl) newTemplate() *template.Template {
 	tmpl := template.New("jobTemplate")
 	tmpl.Delims(leftDelim, rightDelim)
-	tmpl.Option("missingkey=error")
+	tmpl.Option("missingkey=zero")
 	tmpl.Funcs(funcMap(t.consulClient))
 	return tmpl
 }


### PR DESCRIPTION
When performing complex template rendering, it is helpful to be
able to perform if statements based on the existence of a passed
variable like `if .env`. The template runs fine if the variable
is passed, but if it isn't the execution will stop because of the
missingkey setting. This change proposes setting the missingkey
value to zero rather than error. This means that rather than error
out, the operation returns the zero value for the map type's
element and the render execution can continue.