### PR TITLE
test: add basic integration tests

### DIFF
--- a/test/acctest/acctest.go
+++ b/test/acctest/acctest.go
@@ -1,0 +1,144 @@
+package acctest
+
+import (
+	"fmt"
+	"testing"
+
+	nomad "github.com/hashicorp/nomad/api"
+)
+
+// TestCase is a single test of levant
+type TestCase struct {
+	// Steps are ran in order stopping on failure
+	Steps []TestStep
+
+	// CleanupFunc is called at the end of the TestCase
+	CleanupFunc TestStateFunc
+}
+
+// TestStep is a single step within a TestCase
+type TestStep struct {
+	// Runner is used to execute the step, can be nil for a check only step
+	Runner TestStepRunner
+
+	// Check is called after Runner if it does not fail
+	Check TestStateFunc
+
+	// ExpectErr allows Runner to fail, use CheckErr to confirm error is correct
+	ExpectErr bool
+
+	// CheckErr is called if Runner fails and ExpectErr is true
+	CheckErr func(error) bool
+}
+
+// TestStepRunner models a runner for a TestStep
+type TestStepRunner interface {
+	// Run executes the levant feature under testing
+	Run(*TestState) error
+}
+
+// TestStateFunc is used to verify acceptance test criteria
+type TestStateFunc func(*TestState) error
+
+// TestState is the configuration for the TestCase
+type TestState struct {
+	JobName string
+	Nomad   *nomad.Client
+}
+
+// Test executes a single TestCase
+func Test(t *testing.T, c TestCase) {
+	if len(c.Steps) < 1 {
+		t.Fatal("must have at least one test step")
+	}
+
+	nomad, err := newNomadClient()
+	if err != nil {
+		t.Fatalf("failed to create nomad client: %s", err)
+	}
+
+	state := &TestState{
+		JobName: fmt.Sprintf("levant-%s", t.Name()),
+		Nomad:   nomad,
+	}
+
+	for i, step := range c.Steps {
+		stepNum := i + 1
+
+		if step.Runner != nil {
+			err = step.Runner.Run(state)
+			if err != nil {
+				if !step.ExpectErr {
+					t.Errorf("step %d/%d failed: %s", stepNum, len(c.Steps), err)
+					break
+				}
+
+				if step.CheckErr != nil {
+					ok := step.CheckErr(err)
+					if !ok {
+						t.Errorf("step %d/%d CheckErr failed: %s", stepNum, len(c.Steps), err)
+						break
+					}
+				}
+			}
+		}
+
+		if step.Check != nil {
+			err = step.Check(state)
+			if err != nil {
+				t.Errorf("step %d/%d Check failed: %s", stepNum, len(c.Steps), err)
+				break
+			}
+		}
+	}
+
+	if c.CleanupFunc != nil {
+		err = c.CleanupFunc(state)
+		if err != nil {
+			t.Errorf("cleanup failed: %s", err)
+		}
+	}
+}
+
+// CleanupPurgeJob is a cleanup func to purge the TestCase job from Nomad
+func CleanupPurgeJob(s *TestState) error {
+	_, _, err := s.Nomad.Jobs().Deregister(s.JobName, true, nil)
+	return err
+}
+
+// CheckDeploymentStatus is a TestStateFunc to check if the latest deployment of
+// the TestCase job matches the desired status
+func CheckDeploymentStatus(status string) TestStateFunc {
+	return func(s *TestState) error {
+		deploy, _, err := s.Nomad.Jobs().LatestDeployment(s.JobName, nil)
+		if err != nil {
+			return err
+		}
+
+		if deploy.Status != status {
+			return fmt.Errorf("deployment %s is in status '%s', expected '%s'", deploy.ID, deploy.Status, status)
+		}
+
+		return nil
+	}
+}
+
+// newNomadClient creates a Nomad API client configrable by NOMAD_
+// env variables or returns an error if Nomad is in an unhealthy state
+func newNomadClient() (*nomad.Client, error) {
+	c, err := nomad.NewClient(nomad.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Agent().Health()
+	if err != nil {
+		return nil, err
+	}
+
+	if !resp.Server.Ok || !resp.Client.Ok {
+		return nil, fmt.Errorf("agent unhealthy")
+	}
+
+	return c, nil
+}

--- a/test/acctest/deploy.go
+++ b/test/acctest/deploy.go
@@ -1,0 +1,45 @@
+package acctest
+
+import (
+	"fmt"
+
+	"github.com/jrasell/levant/levant"
+	"github.com/jrasell/levant/levant/structs"
+	"github.com/jrasell/levant/template"
+)
+
+// DeployTestStepRunner implements TestStepRunner to execute a levant deployment
+type DeployTestStepRunner struct {
+	FixtureName string
+
+	Canary      int
+	ForceBatch  bool
+	ForceCounts bool
+}
+
+// Run renders the job fixture and triggers a deployment
+func (c DeployTestStepRunner) Run(s *TestState) error {
+	vars := map[string]string{
+		"job_name": s.JobName,
+	}
+	job, err := template.RenderJob("fixtures/"+c.FixtureName, []string{}, "", &vars)
+	if err != nil {
+		return fmt.Errorf("error rendering template: %s", err)
+	}
+
+	cfg := &levant.DeployConfig{
+		Deploy: &structs.DeployConfig{
+			Canary: c.Canary,
+		},
+		Client: &structs.ClientConfig{},
+		Template: &structs.TemplateConfig{
+			Job: job,
+		},
+	}
+
+	if !levant.TriggerDeployment(cfg, nil) {
+		return fmt.Errorf("deployment failed")
+	}
+
+	return nil
+}

--- a/test/deploy_test.go
+++ b/test/deploy_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/jrasell/levant/test/acctest"
+)
+
+func TestDeploy_basic(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_basic.nomad",
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}
+
+func TestDeploy_failure(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_failure.nomad",
+				},
+				ExpectErr: true,
+				CheckErr: func(err error) bool {
+					// this is a bit pointless without the error bubbled up from levant
+					return true
+				},
+			},
+			{
+				// allows us to check a job was registered and previous step error wasn't a parse failure etc.
+				Check: acctest.CheckDeploymentStatus("failed"),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}

--- a/test/fixtures/deploy_basic.nomad
+++ b/test/fixtures/deploy_basic.nomad
@@ -1,0 +1,36 @@
+job "[[.job_name]]" {
+  datacenters = ["dc1"]
+  type = "service"
+  update {
+    max_parallel     = 1
+    min_healthy_time = "10s"
+    healthy_deadline = "1m"
+    auto_revert      = true
+  }
+
+  group "cache" {
+    count = 1
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay = "25s"
+      mode = "delay"
+    }
+    ephemeral_disk {
+      size = 300
+    }
+    task "redis" {
+      driver = "docker"
+      config {
+        image = "redis:alpine"
+      }
+      resources {
+        cpu    = 100
+        memory = 128
+        network {
+          mbits = 10
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/deploy_failure.nomad
+++ b/test/fixtures/deploy_failure.nomad
@@ -1,0 +1,36 @@
+job "[[.job_name]]" {
+  datacenters = ["dc1"]
+  type = "service"
+  update {
+    max_parallel     = 1
+    min_healthy_time = "10s"
+    healthy_deadline = "15s"
+    progress_deadline = "20s"
+  }
+
+  group "cache" {
+    count = 1
+    restart {
+      attempts = 1
+      interval = "10s"
+      delay = "5s"
+      mode = "fail"
+    }
+    ephemeral_disk {
+      size = 300
+    }
+    task "redis" {
+      driver = "docker"
+      config {
+        image = "redis:badimagetag"
+      }
+      resources {
+        cpu    = 100
+        memory = 128
+        network {
+          mbits = 10
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Following on from #51, this PR implements some basic integration tests. Also includes a small testing framework in a similar fashion to Terraform provider acceptance tests to make writing tests simple.

To run, start a Nomad agent in dev mode and run:
```sh
go test -timeout 120s github.com/jrasell/levant/test -v
```