### PR TITLE
test: add count and canary integration tests

### DIFF
--- a/test/acctest/acctest.go
+++ b/test/acctest/acctest.go
@@ -123,6 +123,28 @@ func CheckDeploymentStatus(status string) TestStateFunc {
 	}
 }
 
+// CheckTaskGroupCount is a TestStateFunc to check a TaskGroup count
+func CheckTaskGroupCount(groupName string, count int) TestStateFunc {
+	return func(s *TestState) error {
+		job, _, err := s.Nomad.Jobs().Info(s.JobName, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, group := range job.TaskGroups {
+			if groupName == *group.Name {
+				if *group.Count == count {
+					return nil
+				}
+
+				return fmt.Errorf("task group %s count is %d, expected %d", groupName, *group.Count, count)
+			}
+		}
+
+		return fmt.Errorf("unable to find task group %s", groupName)
+	}
+}
+
 // newNomadClient creates a Nomad API client configrable by NOMAD_
 // env variables or returns an error if Nomad is in an unhealthy state
 func newNomadClient() (*nomad.Client, error) {

--- a/test/acctest/deploy.go
+++ b/test/acctest/deploy.go
@@ -12,24 +12,30 @@ import (
 type DeployTestStepRunner struct {
 	FixtureName string
 
-	Canary      int
-	ForceBatch  bool
-	ForceCounts bool
+	Vars map[string]string
+
+	Canary     int
+	ForceBatch bool
+	ForceCount bool
 }
 
 // Run renders the job fixture and triggers a deployment
 func (c DeployTestStepRunner) Run(s *TestState) error {
-	vars := map[string]string{
-		"job_name": s.JobName,
+	if c.Vars == nil {
+		c.Vars = map[string]string{}
 	}
-	job, err := template.RenderJob("fixtures/"+c.FixtureName, []string{}, "", &vars)
+	c.Vars["job_name"] = s.JobName
+
+	job, err := template.RenderJob("fixtures/"+c.FixtureName, []string{}, "", &c.Vars)
 	if err != nil {
 		return fmt.Errorf("error rendering template: %s", err)
 	}
 
 	cfg := &levant.DeployConfig{
 		Deploy: &structs.DeployConfig{
-			Canary: c.Canary,
+			Canary:     c.Canary,
+			ForceBatch: c.ForceBatch,
+			ForceCount: c.ForceCount,
 		},
 		Client: &structs.ClientConfig{},
 		Template: &structs.TemplateConfig{

--- a/test/deploy_test.go
+++ b/test/deploy_test.go
@@ -20,12 +20,12 @@ func TestDeploy_basic(t *testing.T) {
 	})
 }
 
-func TestDeploy_failure(t *testing.T) {
+func TestDeploy_driverError(t *testing.T) {
 	acctest.Test(t, acctest.TestCase{
 		Steps: []acctest.TestStep{
 			{
 				Runner: acctest.DeployTestStepRunner{
-					FixtureName: "deploy_failure.nomad",
+					FixtureName: "deploy_driver_error.nomad",
 				},
 				ExpectErr: true,
 				CheckErr: func(err error) bool {
@@ -36,6 +36,99 @@ func TestDeploy_failure(t *testing.T) {
 			{
 				// allows us to check a job was registered and previous step error wasn't a parse failure etc.
 				Check: acctest.CheckDeploymentStatus("failed"),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}
+
+func TestDeploy_allocError(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_alloc_error.nomad",
+				},
+				ExpectErr: true,
+				CheckErr: func(err error) bool {
+					// this is a bit pointless without the error bubbled up from levant
+					return true
+				},
+			},
+			{
+				// allows us to check a job was registered and previous step error wasn't a parse failure etc.
+				Check: acctest.CheckDeploymentStatus("failed"),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}
+
+func TestDeploy_count(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_count.nomad",
+					Vars: map[string]string{
+						"count": "3",
+					},
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
+			},
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_count.nomad",
+					Vars: map[string]string{
+						"count": "1",
+					},
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
+			},
+			{
+				// expect levant to read counts from the api
+				Check: acctest.CheckTaskGroupCount("test", 3),
+			},
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_count.nomad",
+					Vars: map[string]string{
+						"count": "1",
+					},
+					ForceCount: true,
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
+			},
+			{
+				Check: acctest.CheckTaskGroupCount("test", 1),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}
+
+func TestDeploy_canary(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_canary.nomad",
+					Canary:      10,
+					Vars: map[string]string{
+						"env_version": "1",
+					},
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
+			},
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_canary.nomad",
+					Canary:      10,
+					Vars: map[string]string{
+						"env_version": "2",
+					},
+				},
+				Check: acctest.CheckDeploymentStatus("successful"),
 			},
 		},
 		CleanupFunc: acctest.CleanupPurgeJob,

--- a/test/fixtures/deploy_alloc_error.nomad
+++ b/test/fixtures/deploy_alloc_error.nomad
@@ -1,3 +1,5 @@
+# test alloc error with a command failure
+
 job "[[.job_name]]" {
   datacenters = ["dc1"]
   type = "service"
@@ -8,7 +10,7 @@ job "[[.job_name]]" {
     progress_deadline = "20s"
   }
 
-  group "cache" {
+  group "test" {
     count = 1
     restart {
       attempts = 1
@@ -19,10 +21,11 @@ job "[[.job_name]]" {
     ephemeral_disk {
       size = 300
     }
-    task "redis" {
+    task "alpine" {
       driver = "docker"
       config {
-        image = "redis:badimagetag"
+        image = "alpine"
+        command = "badcommandname"
       }
       resources {
         cpu    = 100

--- a/test/fixtures/deploy_canary.nomad
+++ b/test/fixtures/deploy_canary.nomad
@@ -1,13 +1,14 @@
-# tests a healthy deployment
+# tests a canary deployment
 
 job "[[.job_name]]" {
   datacenters = ["dc1"]
   type = "service"
   update {
     max_parallel     = 1
-    min_healthy_time = "10s"
+    min_healthy_time = "2s"
     healthy_deadline = "1m"
     auto_revert      = true
+    canary           = 1
   }
 
   group "test" {
@@ -29,6 +30,9 @@ job "[[.job_name]]" {
         args = [
           "-f", "/dev/null"
         ]
+      }
+      env {
+        version = "[[ .env_version ]]"
       }
       resources {
         cpu    = 100

--- a/test/fixtures/deploy_count.nomad
+++ b/test/fixtures/deploy_count.nomad
@@ -1,4 +1,4 @@
-# tests a healthy deployment
+# tests a healthy deployment with a count
 
 job "[[.job_name]]" {
   datacenters = ["dc1"]
@@ -11,7 +11,7 @@ job "[[.job_name]]" {
   }
 
   group "test" {
-    count = 1
+    count = [[.count]]
     restart {
       attempts = 10
       interval = "5m"

--- a/test/fixtures/deploy_driver_error.nomad
+++ b/test/fixtures/deploy_driver_error.nomad
@@ -1,4 +1,4 @@
-# tests a healthy deployment
+# tests driver error with an invalid docker image tag
 
 job "[[.job_name]]" {
   datacenters = ["dc1"]
@@ -6,17 +6,17 @@ job "[[.job_name]]" {
   update {
     max_parallel     = 1
     min_healthy_time = "10s"
-    healthy_deadline = "1m"
-    auto_revert      = true
+    healthy_deadline = "15s"
+    progress_deadline = "20s"
   }
 
   group "test" {
     count = 1
     restart {
-      attempts = 10
-      interval = "5m"
-      delay = "25s"
-      mode = "delay"
+      attempts = 1
+      interval = "10s"
+      delay = "5s"
+      mode = "fail"
     }
     ephemeral_disk {
       size = 300
@@ -24,11 +24,7 @@ job "[[.job_name]]" {
     task "alpine" {
       driver = "docker"
       config {
-        image = "alpine"
-        command = "tail"
-        args = [
-          "-f", "/dev/null"
-        ]
+        image = "alpine:badimagetag"
       }
       resources {
         cpu    = 100


### PR DESCRIPTION
Fixes #51.

```
=== RUN   TestDeploy_basic
--- PASS: TestDeploy_basic (14.45s)
=== RUN   TestDeploy_driverError
--- PASS: TestDeploy_driverError (20.30s)
=== RUN   TestDeploy_allocError
--- PASS: TestDeploy_allocError (20.29s)
=== RUN   TestDeploy_count
--- PASS: TestDeploy_count (26.01s)
=== RUN   TestDeploy_canary
--- PASS: TestDeploy_canary (17.39s)
PASS
ok  	github.com/jrasell/levant/test	98.459s
```