### PR TITLE
Set entrypoint as levant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN buildDeps=' \
         && apk del $buildDeps \
         && echo "Build complete."
 
-CMD ["levant", "--help"]
+ENTRYPOINT ["levant"]
+
+CMD ["--help"]


### PR DESCRIPTION
Runs the container as a binary, so the `docker run` command is `docker run jrasell/levant [--version] [--help] <command> [<args>]`:
```
➜ docker run jrasell/levant version
Levant v0.2.7
Date: 2019-03-19T08:26:24Z
Commit: 9e952d55f171e63f5c7955e826401eac91ed0b28
Branch: 0.2.7
State: 0.2.7
Summary: 9e952d55f171e63f5c7955e826401eac91ed0b28
```
Instead of `docker run jrasell/levant levant [--version] [--help] <command> [<args>]`:
```
$ docker run jrasell/levant levant version
...
```

