### PR TITLE
Add force flag to trigger a deployment even without changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.8 (Unreleased)
 
+ * Add `-force` flag to deploy CLI command which allows for forcing a deployment even if Levant detects 0 changes on plan [GH-296](https://github.com/jrasell/levant/pull/296)
+
 ## 0.2.7 (19 March 2019)
 
 IMPROVEMENTS:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,20 +1,24 @@
 default: check test build
 
+.PHONY: tools
 tools: ## Install the tools used to test and build
 	@echo "==> Installing build tools"
 	go get github.com/ahmetb/govvv
 	go get github.com/alecthomas/gometalinter
 	gometalinter --install
 
+.PHONY: build
 build: ## Build Levant for development purposes
 	@echo "==> Running $@..."
 	govvv build -o levant-local . -version local
 
+.PHONY: test
 test: ## Run the Levant test suite with coverage
 	@echo "==> Running $@..."
 	@go test -cover -v -tags -race \
 		"$(BUILDTAGS)" $(shell go list ./... | grep -v vendor)
 
+.PHONY: release
 release: ## Trigger the release build script
 	@echo "==> Running $@..."
 	@goreleaser --rm-dist

--- a/command/deploy.go
+++ b/command/deploy.go
@@ -51,6 +51,9 @@ General Options:
     The Consul host and port to use when making Consul KeyValue lookups for
     template rendering.
 
+  -force
+    Execute deployment even though there were no changes.
+
   -force-batch
     Forces a new instance of the periodic job. A new instance will be created
     even if it violates the job's prohibit_overlap settings.
@@ -114,6 +117,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.BoolVar(&config.Client.AllowStale, "allow-stale", false, "")
 	flags.IntVar(&config.Deploy.Canary, "canary-auto-promote", 0, "")
 	flags.StringVar(&config.Client.ConsulAddr, "consul-address", "", "")
+	flags.BoolVar(&config.Deploy.Force, "force", false, "")
 	flags.BoolVar(&config.Deploy.ForceBatch, "force-batch", false, "")
 	flags.BoolVar(&config.Deploy.ForceCount, "force-count", false, "")
 	flags.BoolVar(&config.Plan.IgnoreNoChanges, "ignore-no-changes", false, "")
@@ -175,17 +179,19 @@ func (c *DeployCommand) Run(args []string) int {
 		}
 	}
 
-	p := levant.PlanConfig{
-		Client:   config.Client,
-		Plan:     config.Plan,
-		Template: config.Template,
-	}
+	if !config.Deploy.Force {
+		p := levant.PlanConfig{
+			Client:   config.Client,
+			Plan:     config.Plan,
+			Template: config.Template,
+		}
 
-	planSuccess, changes := levant.TriggerPlan(&p)
-	if !planSuccess {
-		return 1
-	} else if !changes && p.Plan.IgnoreNoChanges {
-		return 0
+		planSuccess, changes := levant.TriggerPlan(&p)
+		if !planSuccess {
+			return 1
+		} else if !changes && p.Plan.IgnoreNoChanges {
+			return 0
+		}
 	}
 
 	success := levant.TriggerDeployment(config, nil)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,6 +14,8 @@ Levant supports a number of command line arguments which provide control over th
 
 * **-consul-address** (string: "localhost:8500") The Consul host and port to use when making Consul KeyValue lookups for template rendering.
 
+* **-force** (bool: false) Execute deployment even though there were no changes.
+
 * **-force-batch** (bool: false) Forces a new instance of the periodic job. A new instance will be created even if it violates the job's prohibit_overlap settings.
 
 * **-force-count** (bool: false) Use the taskgroup count from the Nomad job file instead of the count that is obtained from the running job count.

--- a/levant/structs/config.go
+++ b/levant/structs/config.go
@@ -27,6 +27,10 @@ type DeployConfig struct {
 	// until attempting to perform autopromote.
 	Canary int
 
+	// Force is a boolean flag that can be used to force a deployment
+	// even though levant didn't detect any changes.
+	Force bool
+
 	// ForceBatch is a boolean flag that can be used to force a run of a periodic
 	// job upon registration.
 	ForceBatch bool


### PR DESCRIPTION
In some cases it is necessary to deploy a version that was already
deployed. For example, when something unexpected happened
on the Nomad side and not all allocations come up.
To mitigate that, the `force` flag triggers a deployment without
running `plan` before and just blindly forwards the command
to Nomad.