### PR TITLE
Add -strict to error if there is a key missing

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -102,6 +102,7 @@ func (c *DeployCommand) Run(args []string) int {
 
 	var err error
 	var level, format string
+	var strictMode bool
 
 	config := &levant.DeployConfig{
 		Client:   &structs.ClientConfig{},
@@ -125,6 +126,7 @@ func (c *DeployCommand) Run(args []string) int {
 	flags.StringVar(&format, "log-format", "HUMAN", "")
 	flags.StringVar(&config.Deploy.VaultToken, "vault-token", "", "")
 	flags.BoolVar(&config.Deploy.EnvVault, "vault", false, "")
+	flags.BoolVar(&strictMode, "strict", false, "")
 
 	flags.Var((*helper.FlagStringSlice)(&config.Template.VariableFiles), "var-file", "")
 
@@ -159,7 +161,7 @@ func (c *DeployCommand) Run(args []string) int {
 	}
 
 	config.Template.Job, err = template.RenderJob(config.Template.TemplateFile,
-		config.Template.VariableFiles, config.Client.ConsulAddr, &c.Meta.flagVars)
+		config.Template.VariableFiles, config.Client.ConsulAddr, strictMode, &c.Meta.flagVars)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
 		return 1

--- a/command/plan.go
+++ b/command/plan.go
@@ -88,6 +88,7 @@ func (c *PlanCommand) Run(args []string) int {
 		Template: &structs.TemplateConfig{},
 	}
 
+	var strictMode bool
 	flags := c.Meta.FlagSet("plan", FlagSetVars)
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 
@@ -98,6 +99,7 @@ func (c *PlanCommand) Run(args []string) int {
 	flags.StringVar(&level, "log-level", "INFO", "")
 	flags.StringVar(&format, "log-format", "HUMAN", "")
 	flags.Var((*helper.FlagStringSlice)(&config.Template.VariableFiles), "var-file", "")
+	flags.BoolVar(&strictMode, "strict", false, "")
 
 	if err = flags.Parse(args); err != nil {
 		return 1
@@ -124,7 +126,7 @@ func (c *PlanCommand) Run(args []string) int {
 	}
 
 	config.Template.Job, err = template.RenderJob(config.Template.TemplateFile,
-		config.Template.VariableFiles, config.Client.ConsulAddr, &c.Meta.flagVars)
+		config.Template.VariableFiles, config.Client.ConsulAddr, strictMode, &c.Meta.flagVars)
 
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))

--- a/command/render.go
+++ b/command/render.go
@@ -60,6 +60,7 @@ func (c *RenderCommand) Run(args []string) int {
 
 	var addr, outPath, templateFile string
 	var variables []string
+	var strictMode bool
 	var err error
 	var tpl *bytes.Buffer
 
@@ -69,6 +70,7 @@ func (c *RenderCommand) Run(args []string) int {
 	flags.StringVar(&addr, "consul-address", "", "")
 	flags.Var((*helper.FlagStringSlice)(&variables), "var-file", "")
 	flags.StringVar(&outPath, "out", "", "")
+	flags.BoolVar(&strictMode, "strict", false, "")
 
 	if err = flags.Parse(args); err != nil {
 		return 1
@@ -89,7 +91,7 @@ func (c *RenderCommand) Run(args []string) int {
 		return 1
 	}
 
-	tpl, err = template.RenderTemplate(templateFile, variables, addr, &c.Meta.flagVars)
+	tpl, err = template.RenderTemplate(templateFile, variables, addr, strictMode, &c.Meta.flagVars)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("[ERROR] levant/command: %v", err))
 		return 1

--- a/template/render.go
+++ b/template/render.go
@@ -19,9 +19,9 @@ import (
 
 // RenderJob takes in a template and variables performing a render of the
 // template followed by Nomad jobspec parse.
-func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (job *nomad.Job, err error) {
+func RenderJob(templateFile string, variableFiles []string, addr string, strictMode bool, flagVars *map[string]string) (job *nomad.Job, err error) {
 	var tpl *bytes.Buffer
-	tpl, err = RenderTemplate(templateFile, variableFiles, addr, flagVars)
+	tpl, err = RenderTemplate(templateFile, variableFiles, addr, strictMode, flagVars)
 	if err != nil {
 		return
 	}
@@ -32,12 +32,13 @@ func RenderJob(templateFile string, variableFiles []string, addr string, flagVar
 
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
-func RenderTemplate(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func RenderTemplate(templateFile string, variableFiles []string, addr string, strictMode bool, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
 
 	t := &tmpl{}
 	t.flagVariables = flagVars
 	t.jobTemplateFile = templateFile
 	t.variableFiles = variableFiles
+	t.errMissingKey = strictMode
 
 	c, err := client.NewConsulClient(addr)
 	if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -13,6 +13,7 @@ type tmpl struct {
 	flagVariables   *map[string]string
 	jobTemplateFile string
 	variableFiles   []string
+	errMissingKey   bool
 }
 
 const (
@@ -28,7 +29,13 @@ const (
 func (t *tmpl) newTemplate() *template.Template {
 	tmpl := template.New("jobTemplate")
 	tmpl.Delims(leftDelim, rightDelim)
-	tmpl.Option("missingkey=zero")
+
+	if t.errMissingKey {
+		tmpl.Option("missingkey=error")
+	} else {
+		tmpl.Option("missingkey=zero")
+	}
+
 	tmpl.Funcs(funcMap(t.consulClient))
 	return tmpl
 }


### PR DESCRIPTION
Currently if you forget to pass in variable you'll be left with `<no value>` in the template.

This prevents rendering of templates unless all of the variables are set.

```
[ERROR] levant/command: template: jobTemplate:2:3: executing "jobTemplate" at <.foo>: map has no entry for key "foo"
```

Not sure of the name `-strict` 😆  
📝 This should be the default behaviour